### PR TITLE
feat: table redesign — themes, grouped rows, type pills, icon stars

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -1,32 +1,64 @@
-{# Hidden navigation state — lives inside the swap target so it's refreshed on every HTMX response.
-   External controls include this via hx-include="#list-controls, #current-state" to preserve
-   sort and direction across filter/pagination interactions. #}
+{# ── Macros ────────────────────────────────────────────────────────────────── #}
+
+{% macro render_stars(stars_val) %}
+  {% if stars_val %}
+    {% set full  = stars_val | int %}
+    {% set half  = 1 if (stars_val - full) >= 0.5 else 0 %}
+    {% set empty = 5 - full - half %}
+    {% for _ in range(full)  %}<i class="bi bi-star-fill"  style="color: var(--t-star-on);"></i>{% endfor %}
+    {% if half              %}<i class="bi bi-star-half"  style="color: var(--t-star-on);"></i>{% endif %}
+    {% for _ in range(empty) %}<i class="bi bi-star"       style="color: var(--t-star-off);"></i>{% endfor %}
+  {% else %}
+    {% for _ in range(5) %}<i class="bi bi-star" style="color: var(--t-star-off);"></i>{% endfor %}
+  {% endif %}
+{% endmacro %}
+
+{% macro type_pill(bottle_type) %}
+  {% if bottle_type.name in ['BOURBON', 'TENNESSEE_WHISKEY'] %}
+    {% set pill_cls = 'type-pill-bourbon' %}
+  {% elif bottle_type.name == 'RYE' %}
+    {% set pill_cls = 'type-pill-rye' %}
+  {% elif bottle_type.name == 'SCOTCH' %}
+    {% set pill_cls = 'type-pill-scotch' %}
+  {% elif bottle_type.name in ['AMERICAN_WHISKEY', 'AMERICAN_SINGLE_MALT', 'AMERICAN_LIGHT_WHISKEY'] %}
+    {% set pill_cls = 'type-pill-american' %}
+  {% else %}
+    {% set pill_cls = 'type-pill-other' %}
+  {% endif %}
+  <span class="type-pill {{ pill_cls }}">{{ bottle_type.value }}</span>
+{% endmacro %}
+
+{# ── Hidden nav state ─────────────────────────────────────────────────────── #}
+{# Refreshed on every HTMX swap; included by external controls to preserve
+   sort/direction across filter/pagination interactions. #}
 <form id="current-state" hidden>
   <input type="hidden" name="sort" value="{{ sort }}">
   <input type="hidden" name="dir" value="{{ direction }}">
 </form>
 
+{# ── Summary text ─────────────────────────────────────────────────────────── #}
 {% if total > 0 %}
   <p class="text-muted small mb-2">
     Showing {{ (page - 1) * per_page + 1 }}–{{ [page * per_page, total] | min }}
-    of {{ total }} bottle{{ "s" if total != 1 }}
+    of {{ total }} group{{ "s" if total != 1 }}
+    ({{ total_bottles }} bottle{{ "s" if total_bottles != 1 }})
   </p>
 {% endif %}
 
+{# ── Table ────────────────────────────────────────────────────────────────── #}
 <div class="table-responsive">
-  <table class="table table-striped table-hover">
-    <thead style="border-bottom: 1px solid #696969;">
+  <table class="table themed-table">
+    <thead>
       <tr>
 
         {% if is_my_list %}
-          <th class="text-nowrap" style="width: 1%;">&nbsp;</th>
+          <th style="width: 1%;">&nbsp;</th>
         {% endif %}
 
         {# Name — sortable #}
         {% set name_dir = 'desc' if sort == 'name' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ list_url }}"
+          <a hx-get="{{ list_url }}"
             hx-target="#bottle-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -35,7 +67,7 @@
             {% if sort == 'name' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -43,8 +75,7 @@
         {# Single Barrel — sortable #}
         {% set sb_dir = 'desc' if sort == 'sb' and direction == 'asc' else 'asc' %}
         <th class="text-center text-nowrap" style="width: 1%;">
-          <a class="text-dark text-decoration-none"
-            title="Single Barrel" data-bs-toggle="tooltip"
+          <a title="Single Barrel" data-bs-toggle="tooltip"
             hx-get="{{ list_url }}"
             hx-target="#bottle-results"
             hx-push-url="true"
@@ -54,7 +85,7 @@
             {% if sort == 'sb' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -62,8 +93,7 @@
         {# Type — sortable #}
         {% set type_dir = 'desc' if sort == 'type' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ list_url }}"
+          <a hx-get="{{ list_url }}"
             hx-target="#bottle-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -72,7 +102,7 @@
             {% if sort == 'type' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -80,17 +110,16 @@
         {# ABV/Proof — sortable #}
         {% set abv_dir = 'desc' if sort == 'abv' and direction == 'asc' else 'asc' %}
         <th class="text-end text-nowrap">
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ list_url }}"
+          <a hx-get="{{ list_url }}"
             hx-target="#bottle-results"
             hx-push-url="true"
             hx-include="#list-controls"
             hx-vals='{"sort": "abv", "dir": "{{ abv_dir }}", "page": "1"}'>
-            ABV/Proof
+            ABV / Proof
             {% if sort == 'abv' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -98,8 +127,7 @@
         {# Rating — sortable #}
         {% set rating_dir = 'desc' if sort == 'rating' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ list_url }}"
+          <a hx-get="{{ list_url }}"
             hx-target="#bottle-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -108,7 +136,7 @@
             {% if sort == 'rating' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -117,8 +145,7 @@
         {% if is_my_list %}
           {% set priv_dir = 'desc' if sort == 'private' and direction == 'asc' else 'asc' %}
           <th class="text-center text-nowrap" style="width: 1%;">
-            <a class="text-dark text-decoration-none"
-              title="Private" data-bs-toggle="tooltip"
+            <a title="Private" data-bs-toggle="tooltip"
               hx-get="{{ list_url }}"
               hx-target="#bottle-results"
               hx-push-url="true"
@@ -128,7 +155,7 @@
               {% if sort == 'private' %}
                 <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
               {% else %}
-                <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+                <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
               {% endif %}
             </a>
           </th>
@@ -136,87 +163,178 @@
 
       </tr>
     </thead>
-    <tbody>
-      {% if bottles %}
-        {% for bottle in bottles %}
-          <tr class="{{ 'opacity-50' if bottle.date_killed else '' }}">
 
-            {# Edit / Delete — owner only #}
-            {% if is_my_list %}
-              <td class="text-nowrap">
-                <div class="d-inline-flex align-items-center gap-2">
-                  <a href="{{ url_for('bottle.edit', username=bottle.user.username, user_num=bottle.user_num) }}">
-                    <i class="bi bi-pencil"></i>
-                  </a>
-                  <a href="#" data-bs-toggle="modal" data-bs-target="#confirmDelete"
-                    @click="deleteUrl = '{{ url_for('bottle.delete', username=bottle.user.username, user_num=bottle.user_num) }}'">
-                    <i class="bi bi-trash"></i>
-                  </a>
-                </div>
+    {% if grouped %}
+      {% for group in grouped %}
+
+        {% if group.is_group %}
+          {# ── Multi-bottle group: collapsible ────────────────────────────── #}
+          <tbody x-data="{ open: false }">
+
+            {# Group header row #}
+            <tr class="group-row" @click="open = !open">
+
+              {% if is_my_list %}<td></td>{% endif %}
+
+              <td>
+                <i class="bi expand-chevron" :class="open ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
+                <span style="color: var(--t-text-group); font-weight: 500;">{{ group.name | replace("\n", " ") }}</span>
+                <span class="count-badge">×{{ group.count }}</span>
               </td>
-            {% endif %}
 
-            {# Name + image indicator #}
-            <td>
-              <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}">
-                {{ bottle.name | replace("\n", " ") }}
-              </a>
-              {% if bottle.image_count %}
-                <i class="bi bi-file-image ms-1 text-muted" title="Has Image(s)"></i>
-              {% endif %}
-            </td>
-
-            {# Single Barrel #}
-            <td class="text-center pe-4">
-              {% if bottle.is_single_barrel %}
-                <i class="bi bi-check-circle-fill text-secondary" title="Single Barrel"></i>
-              {% endif %}
-            </td>
-
-            {# Type #}
-            <td>{{ bottle.type.value }}</td>
-
-            {# ABV / Proof #}
-            <td class="text-end pe-4 text-nowrap">
-              {% if bottle.abv %}{{ "%.2f" | format(bottle.abv) }}/{{ "%.2f" | format(bottle.abv * 2) }}°{% else %}-{% endif %}
-            </td>
-
-            {# Rating #}
-            <td>
-              {% if bottle.stars %}
-                {% set times_ten = (bottle.stars * 10) | int %}
-                <img src="{{ url_for('static', filename='stars/stars_' + times_ten | string + '.png') }}"
-                  alt="{{ bottle.stars }} Stars" title="{{ bottle.stars }} Stars" class="mb-1">
-              {% else %}
-                <img src="{{ url_for('static', filename='stars/stars_blank.png') }}"
-                  alt="Not yet rated" title="Not yet rated" class="mb-1">
-              {% endif %}
-            </td>
-
-            {# Private — owner only #}
-            {% if is_my_list %}
               <td class="text-center pe-4">
-                {% if bottle.is_private %}
-                  <i class="bi bi-incognito opacity-50" title="Private"></i>
+                {% if group.all_sb %}
+                  <i class="bi bi-check-circle-fill sb-icon" title="All Single Barrel"></i>
                 {% endif %}
               </td>
-            {% endif %}
 
-          </tr>
-        {% endfor %}
-      {% else %}
+              <td>{{ type_pill(group.type) }}</td>
+
+              <td class="text-end pe-4 text-nowrap">
+                {% if group.abv_min is not none %}
+                  {% if group.abv_min == group.abv_max %}
+                    {{ "%.2f" | format(group.abv_min) }}/{{ "%.2f" | format(group.abv_min * 2) }}°
+                  {% else %}
+                    {{ "%.2f" | format(group.abv_min) }}–{{ "%.2f" | format(group.abv_max) }}°
+                  {% endif %}
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+
+              <td>{{ render_stars(group.max_stars) }}</td>
+
+              {% if is_my_list %}<td></td>{% endif %}
+
+            </tr>
+
+            {# Sub-rows — one per bottle in the group #}
+            {% for bottle in group.bottles %}
+              <tr class="sub-row" x-show="open" x-cloak>
+
+                {% if is_my_list %}
+                  <td class="text-nowrap">
+                    <div class="d-inline-flex align-items-center gap-2" style="padding-left: 1.25rem;">
+                      <a href="{{ url_for('bottle.edit', username=bottle.user.username, user_num=bottle.user_num) }}">
+                        <i class="bi bi-pencil"></i>
+                      </a>
+                      <a href="#" data-bs-toggle="modal" data-bs-target="#confirmDelete"
+                        @click="deleteUrl = '{{ url_for('bottle.delete', username=bottle.user.username, user_num=bottle.user_num) }}'">
+                        <i class="bi bi-trash"></i>
+                      </a>
+                    </div>
+                  </td>
+                {% endif %}
+
+                <td style="padding-left: 2rem;">
+                  <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}">
+                    {{ bottle.name | replace("\n", " ") }}
+                  </a>
+                  {% if bottle.image_count %}
+                    <i class="bi bi-file-image ms-1 text-muted" title="Has Image(s)"></i>
+                  {% endif %}
+                </td>
+
+                <td class="text-center pe-4">
+                  {% if bottle.is_single_barrel %}
+                    <i class="bi bi-check-circle-fill sb-icon" title="Single Barrel"></i>
+                  {% endif %}
+                </td>
+
+                <td>{{ type_pill(bottle.type) }}</td>
+
+                <td class="text-end pe-4 text-nowrap">
+                  {% if bottle.abv %}{{ "%.2f" | format(bottle.abv) }}/{{ "%.2f" | format(bottle.abv * 2) }}°{% else %}—{% endif %}
+                </td>
+
+                <td>{{ render_stars(bottle.stars) }}</td>
+
+                {% if is_my_list %}
+                  <td class="text-center pe-4">
+                    {% if bottle.is_private %}
+                      <i class="bi bi-incognito opacity-50" title="Private"></i>
+                    {% endif %}
+                  </td>
+                {% endif %}
+
+              </tr>
+            {% endfor %}
+
+          </tbody>
+
+        {% else %}
+          {# ── Single bottle: flat row ─────────────────────────────────────── #}
+          {% set bottle = group.bottles[0] %}
+          <tbody>
+            <tr class="{{ 'opacity-50' if bottle.date_killed else '' }}">
+
+              {% if is_my_list %}
+                <td class="text-nowrap">
+                  <div class="d-inline-flex align-items-center gap-2">
+                    <a href="{{ url_for('bottle.edit', username=bottle.user.username, user_num=bottle.user_num) }}">
+                      <i class="bi bi-pencil"></i>
+                    </a>
+                    <a href="#" data-bs-toggle="modal" data-bs-target="#confirmDelete"
+                      @click="deleteUrl = '{{ url_for('bottle.delete', username=bottle.user.username, user_num=bottle.user_num) }}'">
+                      <i class="bi bi-trash"></i>
+                    </a>
+                  </div>
+                </td>
+              {% endif %}
+
+              <td>
+                <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}">
+                  {{ bottle.name | replace("\n", " ") }}
+                </a>
+                {% if bottle.image_count %}
+                  <i class="bi bi-file-image ms-1 text-muted" title="Has Image(s)"></i>
+                {% endif %}
+              </td>
+
+              <td class="text-center pe-4">
+                {% if bottle.is_single_barrel %}
+                  <i class="bi bi-check-circle-fill sb-icon" title="Single Barrel"></i>
+                {% endif %}
+              </td>
+
+              <td>{{ type_pill(bottle.type) }}</td>
+
+              <td class="text-end pe-4 text-nowrap">
+                {% if bottle.abv %}{{ "%.2f" | format(bottle.abv) }}/{{ "%.2f" | format(bottle.abv * 2) }}°{% else %}—{% endif %}
+              </td>
+
+              <td>{{ render_stars(bottle.stars) }}</td>
+
+              {% if is_my_list %}
+                <td class="text-center pe-4">
+                  {% if bottle.is_private %}
+                    <i class="bi bi-incognito opacity-50" title="Private"></i>
+                  {% endif %}
+                </td>
+              {% endif %}
+
+            </tr>
+          </tbody>
+
+        {% endif %}
+      {% endfor %}
+
+    {% else %}
+      {# ── Empty state ──────────────────────────────────────────────────────── #}
+      <tbody>
         <tr>
           <td colspan="{{ 5 + (2 if is_my_list else 0) }}"
               class="text-center text-muted py-4">
             {{ empty_text }}
           </td>
         </tr>
-      {% endif %}
-    </tbody>
+      </tbody>
+    {% endif %}
+
   </table>
 </div>
 
-{# Pagination #}
+{# ── Pagination ───────────────────────────────────────────────────────────── #}
 {% if total_pages > 1 %}
   <nav aria-label="Bottle list pages">
     <ul class="pagination pagination-sm justify-content-center">

--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -169,7 +169,7 @@
 
         {% if group.is_group %}
           {# ── Multi-bottle group: collapsible ────────────────────────────── #}
-          <tbody x-data="{ open: false }">
+          <tbody x-data="{ open: false }" class="{{ 'stripe' if loop.index is even else '' }}">
 
             {# Group header row #}
             <tr class="group-row" @click="open = !open">
@@ -265,7 +265,7 @@
         {% else %}
           {# ── Single bottle: flat row ─────────────────────────────────────── #}
           {% set bottle = group.bottles[0] %}
-          <tbody>
+          <tbody class="{{ 'stripe' if loop.index is even else '' }}">
             <tr class="{{ 'opacity-50' if bottle.date_killed else '' }}">
 
               {% if is_my_list %}

--- a/mywhiskies/blueprints/bottle/templates/bottle/list.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/list.html
@@ -12,7 +12,7 @@
           <h1 class="mb-0">{{ heading_02 }}</h1>
         </div>
         <div class="col-auto d-flex pb-1 gap-2">
-          {% if is_my_list and total > 1 %}
+          {% if is_my_list and total_bottles > 1 %}
             <button type="button" class="btn btn-primary text-nowrap" id="random-bottle-btn">
               <i class="bi bi-question-circle"></i> Random Bottle
             </button>

--- a/mywhiskies/blueprints/bottle/templates/bottle/list.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/list.html
@@ -55,6 +55,20 @@
         <!-- Right-side controls -->
         <div class="col-auto ms-auto d-flex gap-2 align-items-center">
 
+          <!-- Theme picker -->
+          <div class="d-flex align-items-center gap-2 me-1">
+            <span class="text-muted" style="font-size: 0.7rem; white-space: nowrap;">Theme:</span>
+            <button @click="setTheme('whiskey-bar')" class="theme-swatch"
+              :class="theme === 'whiskey-bar' ? 'active-swatch' : ''"
+              title="Whiskey Bar" style="background: #3d1f00;"></button>
+            <button @click="setTheme('clean')" class="theme-swatch"
+              :class="theme === 'clean' ? 'active-swatch' : ''"
+              title="Clean" style="background: #e0e0e0;"></button>
+            <button @click="setTheme('dark-cellar')" class="theme-swatch"
+              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
+              title="Dark Cellar" style="background: #1a1008;"></button>
+          </div>
+
           <!-- Per-page selector -->
           <select class="form-select form-select-sm" name="per_page" style="width: auto;"
             hx-get="{{ list_url }}"

--- a/mywhiskies/blueprints/bottle/templates/bottle/list.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/list.html
@@ -64,9 +64,6 @@
             <button @click="setTheme('clean')" class="theme-swatch"
               :class="theme === 'clean' ? 'active-swatch' : ''"
               title="Clean" style="background: #e0e0e0;"></button>
-            <button @click="setTheme('dark-cellar')" class="theme-swatch"
-              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
-              title="Dark Cellar" style="background: #1a1008;"></button>
           </div>
 
           <!-- Per-page selector -->

--- a/mywhiskies/blueprints/bottler/templates/bottler/_bottler_rows.html
+++ b/mywhiskies/blueprints/bottler/templates/bottler/_bottler_rows.html
@@ -78,7 +78,7 @@
     <tbody>
       {% if bottlers %}
         {% for bottler in bottlers %}
-          <tr>
+          <tr style="{{ 'background-color: var(--t-row-bg-alt);' if loop.index is even else '' }}">
 
             {# Edit / Delete — owner only #}
             {% if is_my_list %}

--- a/mywhiskies/blueprints/bottler/templates/bottler/_bottler_rows.html
+++ b/mywhiskies/blueprints/bottler/templates/bottler/_bottler_rows.html
@@ -11,8 +11,8 @@
 {% endif %}
 
 <div class="table-responsive">
-  <table class="table table-striped table-hover">
-    <thead style="border-bottom: 1px solid #696969;">
+  <table class="table themed-table">
+    <thead>
       <tr>
 
         {% if is_my_list %}
@@ -22,8 +22,7 @@
         {# Name — sortable #}
         {% set name_dir = 'desc' if sort == 'name' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ url_for('bottler.list', username=user.username) }}"
+          <a hx-get="{{ url_for('bottler.list', username=user.username) }}"
             hx-target="#bottler-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -32,7 +31,7 @@
             {% if sort == 'name' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -40,8 +39,7 @@
         {# Bottles — sortable #}
         {% set bottles_dir = 'desc' if sort == 'bottles' and direction == 'asc' else 'asc' %}
         <th class="text-end" style="width: 8%;">
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ url_for('bottler.list', username=user.username) }}"
+          <a hx-get="{{ url_for('bottler.list', username=user.username) }}"
             hx-target="#bottler-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -50,7 +48,7 @@
             {% if sort == 'bottles' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -58,8 +56,7 @@
         {# Location — sortable #}
         {% set location_dir = 'desc' if sort == 'location' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ url_for('bottler.list', username=user.username) }}"
+          <a hx-get="{{ url_for('bottler.list', username=user.username) }}"
             hx-target="#bottler-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -68,7 +65,7 @@
             {% if sort == 'location' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>

--- a/mywhiskies/blueprints/bottler/templates/bottler/list.html
+++ b/mywhiskies/blueprints/bottler/templates/bottler/list.html
@@ -37,8 +37,23 @@
             hx-vals='{"page": "1"}'>
         </div>
 
-        <!-- Per-page selector -->
-        <div class="col-auto ms-auto">
+        <!-- Theme picker + Per-page selector -->
+        <div class="col-auto ms-auto d-flex gap-2 align-items-center">
+
+          <div class="d-flex align-items-center gap-2 me-1">
+            <span class="text-muted" style="font-size: 0.7rem; white-space: nowrap;">Theme:</span>
+            <button @click="setTheme('whiskey-bar')" class="theme-swatch"
+              :class="theme === 'whiskey-bar' ? 'active-swatch' : ''"
+              title="Whiskey Bar" style="background: #3d1f00;"></button>
+            <button @click="setTheme('clean')" class="theme-swatch"
+              :class="theme === 'clean' ? 'active-swatch' : ''"
+              title="Clean" style="background: #e0e0e0;"></button>
+            <button @click="setTheme('dark-cellar')" class="theme-swatch"
+              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
+              title="Dark Cellar" style="background: #1a1008;"></button>
+          </div>
+
+        <div>
           <select class="form-select form-select-sm" name="per_page" style="width: auto;"
             hx-get="{{ url_for('bottler.list', username=user.username) }}"
             hx-target="#bottler-results"
@@ -54,6 +69,8 @@
             <option value="10000" {% if per_page == 10000 %}selected{% endif %}>All</option>
           </select>
         </div>
+
+        </div><!-- /col-auto ms-auto -->
 
       </form>
 

--- a/mywhiskies/blueprints/bottler/templates/bottler/list.html
+++ b/mywhiskies/blueprints/bottler/templates/bottler/list.html
@@ -48,9 +48,6 @@
             <button @click="setTheme('clean')" class="theme-swatch"
               :class="theme === 'clean' ? 'active-swatch' : ''"
               title="Clean" style="background: #e0e0e0;"></button>
-            <button @click="setTheme('dark-cellar')" class="theme-swatch"
-              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
-              title="Dark Cellar" style="background: #1a1008;"></button>
           </div>
 
         <div>

--- a/mywhiskies/blueprints/distillery/templates/distillery/_distillery_rows.html
+++ b/mywhiskies/blueprints/distillery/templates/distillery/_distillery_rows.html
@@ -78,7 +78,7 @@
     <tbody>
       {% if distilleries %}
         {% for distillery in distilleries %}
-          <tr>
+          <tr style="{{ 'background-color: var(--t-row-bg-alt);' if loop.index is even else '' }}">
 
             {# Edit / Delete — owner only #}
             {% if is_my_list %}

--- a/mywhiskies/blueprints/distillery/templates/distillery/_distillery_rows.html
+++ b/mywhiskies/blueprints/distillery/templates/distillery/_distillery_rows.html
@@ -11,8 +11,8 @@
 {% endif %}
 
 <div class="table-responsive">
-  <table class="table table-striped table-hover">
-    <thead style="border-bottom: 1px solid #696969;">
+  <table class="table themed-table">
+    <thead>
       <tr>
 
         {% if is_my_list %}
@@ -22,8 +22,7 @@
         {# Name — sortable #}
         {% set name_dir = 'desc' if sort == 'name' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ url_for('distillery.list', username=user.username) }}"
+          <a hx-get="{{ url_for('distillery.list', username=user.username) }}"
             hx-target="#distillery-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -32,7 +31,7 @@
             {% if sort == 'name' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -40,8 +39,7 @@
         {# Bottles — sortable #}
         {% set bottles_dir = 'desc' if sort == 'bottles' and direction == 'asc' else 'asc' %}
         <th class="text-end" style="width: 8%;">
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ url_for('distillery.list', username=user.username) }}"
+          <a hx-get="{{ url_for('distillery.list', username=user.username) }}"
             hx-target="#distillery-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -50,7 +48,7 @@
             {% if sort == 'bottles' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>
@@ -58,8 +56,7 @@
         {# Location — sortable #}
         {% set location_dir = 'desc' if sort == 'location' and direction == 'asc' else 'asc' %}
         <th>
-          <a class="text-dark text-decoration-none"
-            hx-get="{{ url_for('distillery.list', username=user.username) }}"
+          <a hx-get="{{ url_for('distillery.list', username=user.username) }}"
             hx-target="#distillery-results"
             hx-push-url="true"
             hx-include="#list-controls"
@@ -68,7 +65,7 @@
             {% if sort == 'location' %}
               <i class="bi bi-arrow-{{ 'up' if direction == 'asc' else 'down' }}-short"></i>
             {% else %}
-              <i class="bi bi-arrow-down-up text-muted opacity-50" style="font-size: 0.75em;"></i>
+              <i class="bi bi-arrow-down-up opacity-50" style="font-size: 0.75em; color: var(--t-header-text-secondary);"></i>
             {% endif %}
           </a>
         </th>

--- a/mywhiskies/blueprints/distillery/templates/distillery/list.html
+++ b/mywhiskies/blueprints/distillery/templates/distillery/list.html
@@ -37,8 +37,22 @@
             hx-vals='{"page": "1"}'>
         </div>
 
-        <!-- Per-page selector -->
-        <div class="col-auto ms-auto">
+        <!-- Theme picker + Per-page selector -->
+        <div class="col-auto ms-auto d-flex gap-2 align-items-center">
+
+          <div class="d-flex align-items-center gap-2 me-1">
+            <span class="text-muted" style="font-size: 0.7rem; white-space: nowrap;">Theme:</span>
+            <button @click="setTheme('whiskey-bar')" class="theme-swatch"
+              :class="theme === 'whiskey-bar' ? 'active-swatch' : ''"
+              title="Whiskey Bar" style="background: #3d1f00;"></button>
+            <button @click="setTheme('clean')" class="theme-swatch"
+              :class="theme === 'clean' ? 'active-swatch' : ''"
+              title="Clean" style="background: #e0e0e0;"></button>
+            <button @click="setTheme('dark-cellar')" class="theme-swatch"
+              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
+              title="Dark Cellar" style="background: #1a1008;"></button>
+          </div>
+
           <select class="form-select form-select-sm" name="per_page" style="width: auto;"
             hx-get="{{ url_for('distillery.list', username=user.username) }}"
             hx-target="#distillery-results"
@@ -53,6 +67,7 @@
             {% endfor %}
             <option value="10000" {% if per_page == 10000 %}selected{% endif %}>All</option>
           </select>
+
         </div>
 
       </form>

--- a/mywhiskies/blueprints/distillery/templates/distillery/list.html
+++ b/mywhiskies/blueprints/distillery/templates/distillery/list.html
@@ -48,9 +48,6 @@
             <button @click="setTheme('clean')" class="theme-swatch"
               :class="theme === 'clean' ? 'active-swatch' : ''"
               title="Clean" style="background: #e0e0e0;"></button>
-            <button @click="setTheme('dark-cellar')" class="theme-swatch"
-              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
-              title="Dark Cellar" style="background: #1a1008;"></button>
           </div>
 
           <select class="form-select form-select-sm" name="per_page" style="width: auto;"

--- a/mywhiskies/services/bottle/bottle.py
+++ b/mywhiskies/services/bottle/bottle.py
@@ -1,4 +1,5 @@
 import random
+from itertools import groupby
 from typing import Dict, List, Optional, Union
 
 import boto3
@@ -21,6 +22,41 @@ _SORT_FNS = {
     "sb": lambda b: b.is_single_barrel,
     "private": lambda b: b.is_private,
 }
+
+_GROUP_SORT_FNS = {
+    "name": lambda g: g["name"].lower(),
+    "type": lambda g: g["type"].value.lower(),
+    "abv": lambda g: g["abv_max"] or 0.0,
+    "rating": lambda g: g["max_stars"] or 0.0,
+    "sb": lambda g: g["all_sb"],
+    "private": lambda g: any(b.is_private for b in g["bottles"]),
+}
+
+
+def _make_groups(bottles: list) -> list:
+    """Group bottles by (name, type) into dicts with aggregate display values."""
+    bottles_sorted = sorted(bottles, key=lambda b: (b.name.lower(), b.type.name))
+    groups = []
+    for _, group_iter in groupby(
+        bottles_sorted, key=lambda b: (b.name.lower(), b.type.name)
+    ):
+        items = list(group_iter)
+        abvs = [float(b.abv) for b in items if b.abv]
+        stars_vals = [float(b.stars) for b in items if b.stars]
+        groups.append(
+            {
+                "name": items[0].name,
+                "type": items[0].type,
+                "count": len(items),
+                "bottles": items,
+                "is_group": len(items) > 1,
+                "abv_min": min(abvs) if abvs else None,
+                "abv_max": max(abvs) if abvs else None,
+                "max_stars": max(stars_vals) if stars_vals else None,
+                "all_sb": all(b.is_single_barrel for b in items),
+            }
+        )
+    return groups
 
 
 def list_bottles_by_user(
@@ -51,16 +87,23 @@ def list_bottles_by_user(
         q_lower = q.lower()
         bottles = [b for b in bottles if q_lower in b.name.lower()]
 
-    total = len(bottles)
-    bottles.sort(key=_SORT_FNS.get(sort, _SORT_FNS["name"]), reverse=(direction == "desc"))
+    groups = _make_groups(bottles)
+    groups.sort(
+        key=_GROUP_SORT_FNS.get(sort, _GROUP_SORT_FNS["name"]),
+        reverse=(direction == "desc"),
+    )
+
+    total = len(groups)
+    total_bottles = sum(g["count"] for g in groups)
 
     total_pages = max(1, (total + per_page - 1) // per_page)
     page = min(page, total_pages)
     offset = (page - 1) * per_page
 
     return {
-        "bottles": bottles[offset : offset + per_page],
+        "grouped": groups[offset : offset + per_page],
         "total": total,
+        "total_bottles": total_bottles,
         "page": page,
         "per_page": per_page,
         "total_pages": total_pages,
@@ -96,16 +139,23 @@ def list_bottles_for_entity(
         q_lower = q.lower()
         bottles = [b for b in bottles if q_lower in b.name.lower()]
 
-    total = len(bottles)
-    bottles.sort(key=_SORT_FNS.get(sort, _SORT_FNS["name"]), reverse=(direction == "desc"))
+    groups = _make_groups(bottles)
+    groups.sort(
+        key=_GROUP_SORT_FNS.get(sort, _GROUP_SORT_FNS["name"]),
+        reverse=(direction == "desc"),
+    )
+
+    total = len(groups)
+    total_bottles = sum(g["count"] for g in groups)
 
     total_pages = max(1, (total + per_page - 1) // per_page)
     page = min(page, total_pages)
     offset = (page - 1) * per_page
 
     return {
-        "bottles": bottles[offset : offset + per_page],
+        "grouped": groups[offset : offset + per_page],
         "total": total,
+        "total_bottles": total_bottles,
         "page": page,
         "per_page": per_page,
         "total_pages": total_pages,

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -258,33 +258,6 @@ ul.terms li {
   --t-pill-other-bg: #f0f0f0;    --t-pill-other-text: #666;
 }
 
-[data-theme="dark-cellar"] {
-  --t-header-bg: #1a1008;
-  --t-header-text: #8a7055;
-  --t-header-text-secondary: #5a4030;
-  --t-row-bg: #1a1008;
-  --t-row-bg-alt: #1f1509;
-  --t-row-bg-hover: #231508;
-  --t-row-bg-group: #1f1408;
-  --t-row-bg-sub: #150e05;
-  --t-row-border: #2a1c0a;
-  --t-text-primary: #e8d5b0;
-  --t-text-secondary: #a08060;
-  --t-text-group: #f5e4c0;
-  --t-accent: #c8a030;
-  --t-star-on: #e8a020;
-  --t-star-off: #3a2810;
-  --t-sb-color: #c8a030;
-  --t-badge-bg: #3a2810;
-  --t-badge-text: #c8a870;
-  --t-expand-color: #8a7055;
-  --t-pill-bourbon-bg: #3a2810;  --t-pill-bourbon-text: #c8a870;
-  --t-pill-rye-bg: #1a2810;      --t-pill-rye-text: #7ab870;
-  --t-pill-scotch-bg: #102030;   --t-pill-scotch-text: #70a8d8;
-  --t-pill-american-bg: #1e1830; --t-pill-american-text: #a090d8;
-  --t-pill-other-bg: #2a1c0a;    --t-pill-other-text: #a08060;
-}
-
 
 /* ===================================================================
    THEMED TABLE COMPONENT

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -192,3 +192,247 @@ ul.terms li {
   transition: transform 0.3s ease; /* Smooth animation */
   z-index: 10; /* Ensures the hovered image appears on top */
 }
+
+
+/* ===================================================================
+   ALPINE — prevent flash of unstyled content on x-cloak elements
+   =================================================================== */
+[x-cloak] { display: none !important; }
+
+
+/* ===================================================================
+   TABLE THEMES — CSS custom properties scoped to data-theme
+   =================================================================== */
+
+[data-theme="whiskey-bar"] {
+  --t-header-bg: #3d1f00;
+  --t-header-text: #f5c842;
+  --t-header-text-secondary: #c8a030;
+  --t-row-bg: #ffffff;
+  --t-row-bg-hover: #fdf6ee;
+  --t-row-bg-group: #fdf0dc;
+  --t-row-bg-sub: #fffaf5;
+  --t-row-border: #e8ddd0;
+  --t-text-primary: #2c1a00;
+  --t-text-secondary: #5a4030;
+  --t-text-group: #884800;
+  --t-accent: #884800;
+  --t-star-on: #f5a623;
+  --t-star-off: #ddd;
+  --t-sb-color: #884800;
+  --t-badge-bg: #884800;
+  --t-badge-text: #ffd98c;
+  --t-expand-color: #884800;
+  --t-pill-bourbon-bg: #fdf0dc;  --t-pill-bourbon-text: #884800;
+  --t-pill-rye-bg: #eaf3de;      --t-pill-rye-text: #27500a;
+  --t-pill-scotch-bg: #e6f1fb;   --t-pill-scotch-text: #0c447c;
+  --t-pill-american-bg: #eeedfe; --t-pill-american-text: #3c3489;
+  --t-pill-other-bg: #f0ece8;    --t-pill-other-text: #5a4030;
+}
+
+[data-theme="clean"] {
+  --t-header-bg: #f8f8f8;
+  --t-header-text: #444;
+  --t-header-text-secondary: #888;
+  --t-row-bg: #ffffff;
+  --t-row-bg-hover: #f5f5f5;
+  --t-row-bg-group: #f9f9f9;
+  --t-row-bg-sub: #f5f5f5;
+  --t-row-border: #e5e5e5;
+  --t-text-primary: #1a1a1a;
+  --t-text-secondary: #666;
+  --t-text-group: #333;
+  --t-accent: #378add;
+  --t-star-on: #f5a623;
+  --t-star-off: #ddd;
+  --t-sb-color: #378add;
+  --t-badge-bg: #e6f1fb;
+  --t-badge-text: #0c447c;
+  --t-expand-color: #888;
+  --t-pill-bourbon-bg: #faeeda;  --t-pill-bourbon-text: #633806;
+  --t-pill-rye-bg: #eaf3de;      --t-pill-rye-text: #27500a;
+  --t-pill-scotch-bg: #e6f1fb;   --t-pill-scotch-text: #0c447c;
+  --t-pill-american-bg: #eeedfe; --t-pill-american-text: #3c3489;
+  --t-pill-other-bg: #f0f0f0;    --t-pill-other-text: #666;
+}
+
+[data-theme="dark-cellar"] {
+  --t-header-bg: #1a1008;
+  --t-header-text: #8a7055;
+  --t-header-text-secondary: #5a4030;
+  --t-row-bg: #1a1008;
+  --t-row-bg-hover: #231508;
+  --t-row-bg-group: #1f1408;
+  --t-row-bg-sub: #150e05;
+  --t-row-border: #2a1c0a;
+  --t-text-primary: #e8d5b0;
+  --t-text-secondary: #a08060;
+  --t-text-group: #f5e4c0;
+  --t-accent: #c8a030;
+  --t-star-on: #e8a020;
+  --t-star-off: #3a2810;
+  --t-sb-color: #c8a030;
+  --t-badge-bg: #3a2810;
+  --t-badge-text: #c8a870;
+  --t-expand-color: #8a7055;
+  --t-pill-bourbon-bg: #3a2810;  --t-pill-bourbon-text: #c8a870;
+  --t-pill-rye-bg: #1a2810;      --t-pill-rye-text: #7ab870;
+  --t-pill-scotch-bg: #102030;   --t-pill-scotch-text: #70a8d8;
+  --t-pill-american-bg: #1e1830; --t-pill-american-text: #a090d8;
+  --t-pill-other-bg: #2a1c0a;    --t-pill-other-text: #a08060;
+}
+
+
+/* ===================================================================
+   THEMED TABLE COMPONENT
+   =================================================================== */
+
+.themed-table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.themed-table thead {
+  background-color: var(--t-header-bg);
+}
+
+.themed-table thead th {
+  color: var(--t-header-text);
+  border: none;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.65rem 0.75rem;
+  white-space: nowrap;
+}
+
+.themed-table thead th a,
+.themed-table thead th a:hover {
+  color: var(--t-header-text) !important;
+  text-decoration: none !important;
+}
+
+.themed-table tbody tr {
+  background-color: var(--t-row-bg);
+  border-bottom: 1px solid var(--t-row-border);
+  transition: background-color 0.1s ease;
+}
+
+.themed-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.themed-table tbody tr:hover {
+  background-color: var(--t-row-bg-hover);
+}
+
+.themed-table tbody td {
+  color: var(--t-text-primary);
+  padding: 0.55rem 0.75rem;
+  vertical-align: middle;
+  border: none;
+}
+
+.themed-table tbody td a {
+  color: var(--t-accent);
+}
+
+.themed-table tbody td a:hover {
+  color: var(--t-accent);
+  text-decoration: underline;
+}
+
+/* Group rows */
+.themed-table .group-row {
+  background-color: var(--t-row-bg-group) !important;
+  cursor: pointer;
+  user-select: none;
+}
+
+.themed-table .group-row:hover {
+  filter: brightness(0.97);
+}
+
+/* Sub rows */
+.themed-table .sub-row {
+  background-color: var(--t-row-bg-sub) !important;
+}
+
+.themed-table .sub-row:hover {
+  filter: brightness(0.97) !important;
+}
+
+/* Count badge */
+.count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.3rem;
+  height: 1.3rem;
+  padding: 0 0.35rem;
+  border-radius: 0.75rem;
+  background-color: var(--t-badge-bg);
+  color: var(--t-badge-text);
+  font-size: 0.68rem;
+  font-weight: 700;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+/* Expand chevron */
+.expand-chevron {
+  color: var(--t-expand-color);
+  font-size: 0.7rem;
+  margin-right: 0.3rem;
+  vertical-align: middle;
+}
+
+/* SB icon */
+.sb-icon {
+  color: var(--t-sb-color);
+}
+
+/* Type pills */
+.type-pill {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.75rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+.type-pill-bourbon  { background-color: var(--t-pill-bourbon-bg);  color: var(--t-pill-bourbon-text); }
+.type-pill-rye      { background-color: var(--t-pill-rye-bg);      color: var(--t-pill-rye-text); }
+.type-pill-scotch   { background-color: var(--t-pill-scotch-bg);   color: var(--t-pill-scotch-text); }
+.type-pill-american { background-color: var(--t-pill-american-bg); color: var(--t-pill-american-text); }
+.type-pill-other    { background-color: var(--t-pill-other-bg);    color: var(--t-pill-other-text); }
+
+
+/* ===================================================================
+   THEME PICKER SWATCHES (navbar)
+   =================================================================== */
+
+.theme-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.theme-swatch:hover {
+  transform: scale(1.25);
+}
+
+.theme-swatch.active-swatch {
+  outline: 2px solid rgba(255, 255, 255, 0.75);
+  outline-offset: 1px;
+}

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -209,6 +209,7 @@ ul.terms li {
   --t-header-text: #f5c842;
   --t-header-text-secondary: #c8a030;
   --t-row-bg: #ffffff;
+  --t-row-bg-alt: #faf7f2;
   --t-row-bg-hover: #fdf6ee;
   --t-row-bg-group: #fdf0dc;
   --t-row-bg-sub: #fffaf5;
@@ -235,6 +236,7 @@ ul.terms li {
   --t-header-text: #444;
   --t-header-text-secondary: #888;
   --t-row-bg: #ffffff;
+  --t-row-bg-alt: #f7f7f7;
   --t-row-bg-hover: #f5f5f5;
   --t-row-bg-group: #f9f9f9;
   --t-row-bg-sub: #f5f5f5;
@@ -261,6 +263,7 @@ ul.terms li {
   --t-header-text: #8a7055;
   --t-header-text-secondary: #5a4030;
   --t-row-bg: #1a1008;
+  --t-row-bg-alt: #1f1509;
   --t-row-bg-hover: #231508;
   --t-row-bg-group: #1f1408;
   --t-row-bg-sub: #150e05;
@@ -342,6 +345,12 @@ ul.terms li {
 .themed-table tbody td a:hover {
   color: var(--t-accent);
   text-decoration: underline;
+}
+
+/* Zebra striping — applied per-tbody via a Jinja loop.index class;
+   group-row and sub-row !important backgrounds take precedence */
+.themed-table tbody.stripe > tr {
+  background-color: var(--t-row-bg-alt);
 }
 
 /* Group rows */

--- a/mywhiskies/templates/_base.html
+++ b/mywhiskies/templates/_base.html
@@ -4,10 +4,12 @@
 <!doctype html>
 <html lang="en">
   {% include "head.html" %}
+{% set _saved_theme = request.cookies.get('bottle_theme', 'clean') %}
+{% set _initial_theme = _saved_theme if _saved_theme in ['whiskey-bar', 'clean'] else 'clean' %}
 <body
-  data-theme="{{ request.cookies.get('bottle_theme', 'clean') }}"
+  data-theme="{{ _initial_theme }}"
   x-data="{
-    theme: '{{ request.cookies.get('bottle_theme', 'clean') }}',
+    theme: '{{ _initial_theme }}',
     setTheme(t) {
       this.theme = t;
       document.cookie = 'bottle_theme=' + t + '; path=/; max-age=31536000';

--- a/mywhiskies/templates/_base.html
+++ b/mywhiskies/templates/_base.html
@@ -4,7 +4,16 @@
 <!doctype html>
 <html lang="en">
   {% include "head.html" %}
-<body>
+<body
+  data-theme="{{ request.cookies.get('bottle_theme', 'clean') }}"
+  x-data="{
+    theme: '{{ request.cookies.get('bottle_theme', 'clean') }}',
+    setTheme(t) {
+      this.theme = t;
+      document.cookie = 'bottle_theme=' + t + '; path=/; max-age=31536000';
+    }
+  }"
+  :data-theme="theme">
   {% include "navbar.html" %}
   {% block content %}
     <div class="w-100">

--- a/mywhiskies/templates/navbar.html
+++ b/mywhiskies/templates/navbar.html
@@ -56,20 +56,6 @@
             </li>
           </ul>
 
-          <!-- Theme picker -->
-          <div class="d-flex align-items-center gap-2 ms-3 me-2">
-            <span style="font-size: 0.7rem; opacity: 0.6; white-space: nowrap;">Theme:</span>
-            <button @click="setTheme('whiskey-bar')" class="theme-swatch"
-              :class="theme === 'whiskey-bar' ? 'active-swatch' : ''"
-              title="Whiskey Bar" style="background: #3d1f00;"></button>
-            <button @click="setTheme('clean')" class="theme-swatch"
-              :class="theme === 'clean' ? 'active-swatch' : ''"
-              title="Clean" style="background: #e0e0e0;"></button>
-            <button @click="setTheme('dark-cellar')" class="theme-swatch"
-              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
-              title="Dark Cellar" style="background: #1a1008;"></button>
-          </div>
-
           <ul class="navbar-nav ms-auto me-2">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownUser" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/mywhiskies/templates/navbar.html
+++ b/mywhiskies/templates/navbar.html
@@ -56,6 +56,20 @@
             </li>
           </ul>
 
+          <!-- Theme picker -->
+          <div class="d-flex align-items-center gap-2 ms-3 me-2">
+            <span style="font-size: 0.7rem; opacity: 0.6; white-space: nowrap;">Theme:</span>
+            <button @click="setTheme('whiskey-bar')" class="theme-swatch"
+              :class="theme === 'whiskey-bar' ? 'active-swatch' : ''"
+              title="Whiskey Bar" style="background: #3d1f00;"></button>
+            <button @click="setTheme('clean')" class="theme-swatch"
+              :class="theme === 'clean' ? 'active-swatch' : ''"
+              title="Clean" style="background: #e0e0e0;"></button>
+            <button @click="setTheme('dark-cellar')" class="theme-swatch"
+              :class="theme === 'dark-cellar' ? 'active-swatch' : ''"
+              title="Dark Cellar" style="background: #1a1008;"></button>
+          </div>
+
           <ul class="navbar-nav ms-auto me-2">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownUser" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/tests/unit/bottle/test_bottle_service.py
+++ b/tests/unit/bottle/test_bottle_service.py
@@ -17,33 +17,36 @@ from mywhiskies.services.bottle.bottle import (
 
 def test_list_bottles_returns_all(test_user_01: User) -> None:
     data = list_bottles_by_user(user=test_user_01, is_my_list=True)
-    assert "bottles" in data
+    assert "grouped" in data
     assert "total" in data
     assert "has_killed" in data
-    assert data["total"] == len(test_user_01.bottles)
+    assert data["total_bottles"] == len(test_user_01.bottles)
 
 
 def test_list_bottles_hides_private_for_guests(test_user_01: User) -> None:
     data = list_bottles_by_user(user=test_user_01, is_my_list=False)
-    assert all(not b.is_private for b in data["bottles"])
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert all(not b.is_private for b in all_bottles)
 
 
 def test_list_bottles_search(test_user_01: User) -> None:
     first_name = test_user_01.bottles[0].name.split()[0].lower()
     data = list_bottles_by_user(user=test_user_01, is_my_list=True, q=first_name)
-    assert all(first_name in b.name.lower() for b in data["bottles"])
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert all(first_name in b.name.lower() for b in all_bottles)
 
 
 def test_list_bottles_type_filter(test_user_01: User) -> None:
     data = list_bottles_by_user(
         user=test_user_01, is_my_list=True, types=[BottleTypes.BOURBON.name]
     )
-    assert all(b.type == BottleTypes.BOURBON for b in data["bottles"])
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert all(b.type == BottleTypes.BOURBON for b in all_bottles)
 
 
 def test_list_bottles_pagination(test_user_01: User) -> None:
     data = list_bottles_by_user(user=test_user_01, is_my_list=True, per_page=1, page=1)
-    assert len(data["bottles"]) == 1
+    assert len(data["grouped"]) == 1
     assert data["total_pages"] == data["total"]
 
 
@@ -55,16 +58,17 @@ def test_get_random_bottle(test_user_01: User) -> None:
 def test_list_bottles_for_entity_returns_dict(test_user_01: User) -> None:
     bottler = test_user_01.bottlers[0]
     data = list_bottles_for_entity(entity=bottler, is_my_list=True)
-    assert "bottles" in data
+    assert "grouped" in data
     assert "total" in data
     assert "has_killed" in data
-    assert data["total"] == len(bottler.bottles)
+    assert data["total_bottles"] == len(bottler.bottles)
 
 
 def test_list_bottles_for_entity_hides_private_for_guests(test_user_01: User) -> None:
     bottler = test_user_01.bottlers[0]
     data = list_bottles_for_entity(entity=bottler, is_my_list=False)
-    assert all(not b.is_private for b in data["bottles"])
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert all(not b.is_private for b in all_bottles)
 
 
 @patch("mywhiskies.services.bottle.bottle.add_bottle_images")


### PR DESCRIPTION
## Summary

Visual overhaul of the bottle, bottler, and distillery list tables.

**Theme system**
- Three themes: Whiskey Bar (warm amber), Clean (modern light), Dark Cellar
- Theme picker (3 color swatches) displayed above each list table in the filter controls area
- `bottle_theme` cookie persists the selection (1-year expiry) universally across all list views
- Alpine.js drives interactive switching; server pre-renders from cookie to avoid flash on load

**Grouped bottle rows**
- Bottles with identical (name, type) collapse into a single group row with a count badge (×N), ABV range, highest rating, and SB indicator if all match
- Clicking the group row expands/collapses per-bottle sub-rows (Alpine `x-data`/`x-show`)
- Single-entry groups render as flat rows with no expand affordance
- Applied to both the main bottle list and bottler/distillery detail bottle lists
- Pagination is now by groups; summary shows "X groups (N bottles)"

**Other**
- Subtle zebra striping on all themed tables, with stripe color defined per theme via CSS custom properties
- Star ratings switched from PNG images to Bootstrap Icon glyphs colored via CSS custom properties
- Type column replaced with color-coded pill labels (Bourbon, Rye, Scotch, American, etc.)
- Sort arrows use theme CSS vars instead of hard-coded Bootstrap classes

## Test plan

- [x] All 191 tests pass
- [ ] Verify theme picker swatches appear above each list table
- [ ] Verify theme cookie persists across page navigation
- [ ] Verify zebra striping appears on all three list tables
- [ ] Verify grouped rows expand/collapse correctly
- [ ] Verify single-bottle groups render as flat rows
- [ ] Verify type pills and icon stars render in all three themes