### PR TITLE
fix: align group row names with single-bottle rows

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -177,9 +177,9 @@
               {% if is_my_list %}<td></td>{% endif %}
 
               <td>
-                <i class="bi expand-chevron" :class="open ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
                 <span style="color: var(--t-text-group); font-weight: 500;">{{ group.name | replace("\n", " ") }}</span>
                 <span class="count-badge">×{{ group.count }}</span>
+                <i class="bi expand-chevron ms-1" :class="open ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
               </td>
 
               <td class="text-center pe-4">


### PR DESCRIPTION
## Summary

- Move the expand/collapse chevron in group rows from before the bottle name to after the count badge
- All names in the Name column now start at the same left edge, whether the row is a multi-bottle group or a single bottle

## Test plan

- [x] 191 tests pass
- [ ] Verify group row names align with single-bottle row names
- [ ] Verify chevron still toggles expand/collapse on click