### PR TITLE
feat: ABV/Proof toggle in bottle list column header

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -313,7 +313,10 @@
               <td>{{ type_pill(bottle.type) }}</td>
 
               <td class="text-end pe-4 text-nowrap">
-                {% if bottle.abv %}{{ "%.2f" | format(bottle.abv) }}/{{ "%.2f" | format(bottle.abv * 2) }}°{% else %}—{% endif %}
+                {% if bottle.abv %}
+                  <span x-show="$store.abvDisplay.pref === 'abv'">{{ "%.2f" | format(bottle.abv) }}°</span>
+                  <span x-show="$store.abvDisplay.pref === 'proof'">{{ "%.2f" | format(bottle.abv * 2) }}°</span>
+                {% else %}—{% endif %}
               </td>
 
               <td>{{ render_stars(bottle.stars) }}</td>


### PR DESCRIPTION
## Summary

- Replaces the static "ABV / Proof" column header with a compact `<select>` input letting the user switch between ABV and Proof display
- Selection is persisted in a cookie (`abv_display`) for 1 year
- Implemented via an Alpine.js store (`abvDisplay`) with `x-show` toggling the correct span in every row type — group headers (including ranges), group sub-rows, and single-bottle rows
- No server round-trip needed; toggling is instant and survives HTMX swaps automatically since the store is global