### PR TITLE
feat: sub-row icon alignment and zebra striping for expanded groups

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -220,11 +220,11 @@
 
             {# Sub-rows — one per bottle in the group #}
             {% for bottle in group.bottles %}
-              <tr class="sub-row" x-show="open" x-cloak>
+              <tr class="sub-row {{ 'sub-stripe' if loop.index is even else '' }}" x-show="open" x-cloak>
 
                 {% if is_my_list %}
                   <td class="text-nowrap">
-                    <div class="d-inline-flex align-items-center gap-2" style="padding-left: 1.25rem;">
+                    <div class="d-inline-flex align-items-center gap-2">
                       <a href="{{ url_for('bottle.edit', username=bottle.user.username, user_num=bottle.user_num) }}">
                         <i class="bi bi-pencil"></i>
                       </a>

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -213,6 +213,7 @@ ul.terms li {
   --t-row-bg-hover: #fdf6ee;
   --t-row-bg-group: #fdf0dc;
   --t-row-bg-sub: #fffaf5;
+  --t-row-bg-sub-alt: #fef3e4;
   --t-row-border: #e8ddd0;
   --t-text-primary: #2c1a00;
   --t-text-secondary: #5a4030;
@@ -240,6 +241,7 @@ ul.terms li {
   --t-row-bg-hover: #f5f5f5;
   --t-row-bg-group: #e8f3fb;
   --t-row-bg-sub: #f5f5f5;
+  --t-row-bg-sub-alt: #edf5fb;
   --t-row-border: #e5e5e5;
   --t-text-primary: #1a1a1a;
   --t-text-secondary: #666;
@@ -340,6 +342,10 @@ ul.terms li {
 /* Sub rows */
 .themed-table .sub-row {
   background-color: var(--t-row-bg-sub) !important;
+}
+
+.themed-table .sub-row.sub-stripe {
+  background-color: var(--t-row-bg-sub-alt) !important;
 }
 
 .themed-table .sub-row:hover {


### PR DESCRIPTION
## Summary

- Remove the indent from the edit/delete icon container in group sub-rows so icons align vertically with single-bottle row icons; bottle names remain indented (`padding-left: 2rem`) to preserve the visual hierarchy
- Add alternating background colors to sub-rows when a group is expanded, using theme-specific tints distinct from the single-bottle zebra stripes:
  - **Clean**: `#f5f5f5` / `#edf5fb` (faint blue echo of the group header)
  - **Whiskey Bar**: `#fffaf5` / `#fef3e4` (slightly warmer alternate)