### PR TITLE
fix: sub-row zebra stripe colors and group separator

### DIFF
--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -212,8 +212,8 @@ ul.terms li {
   --t-row-bg-alt: #faf7f2;
   --t-row-bg-hover: #fdf6ee;
   --t-row-bg-group: #fdf0dc;
-  --t-row-bg-sub: #fffaf5;
-  --t-row-bg-sub-alt: #fef3e4;
+  --t-row-bg-sub: #fde8c5;
+  --t-row-bg-sub-alt: #fff8f0;
   --t-row-border: #e8ddd0;
   --t-text-primary: #2c1a00;
   --t-text-secondary: #5a4030;
@@ -240,8 +240,8 @@ ul.terms li {
   --t-row-bg-alt: #f7f7f7;
   --t-row-bg-hover: #f5f5f5;
   --t-row-bg-group: #e8f3fb;
-  --t-row-bg-sub: #f5f5f5;
-  --t-row-bg-sub-alt: #edf5fb;
+  --t-row-bg-sub: #e0ecf7;
+  --t-row-bg-sub-alt: #f4f9fd;
   --t-row-border: #e5e5e5;
   --t-text-primary: #1a1a1a;
   --t-text-secondary: #666;
@@ -346,6 +346,10 @@ ul.terms li {
 
 .themed-table .sub-row.sub-stripe {
   background-color: var(--t-row-bg-sub-alt) !important;
+}
+
+.themed-table .sub-row:last-child {
+  border-bottom: 1px solid var(--t-row-border) !important;
 }
 
 .themed-table .sub-row:hover {


### PR DESCRIPTION
## Summary

- Increase contrast of sub-row alternating colors so they're clearly distinct from the group header row and from the single-bottle zebra stripes in both themes:
  - **Clean**: `#e0ecf7` / `#f4f9fd` (medium and very light blue)
  - **Whiskey Bar**: `#fde8c5` / `#fff8f0` (medium and very light warm)
- Restore `border-bottom` on the last sub-row so expanded groups are visually closed off from the row that follows