### PR TITLE
tweak: swap group header and sub-row base colors for both themes

### DIFF
--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -211,8 +211,8 @@ ul.terms li {
   --t-row-bg: #ffffff;
   --t-row-bg-alt: #faf7f2;
   --t-row-bg-hover: #fdf6ee;
-  --t-row-bg-group: #fdf0dc;
-  --t-row-bg-sub: #fde8c5;
+  --t-row-bg-group: #fde8c5;
+  --t-row-bg-sub: #fdf0dc;
   --t-row-bg-sub-alt: #fff8f0;
   --t-row-border: #e8ddd0;
   --t-text-primary: #2c1a00;
@@ -239,8 +239,8 @@ ul.terms li {
   --t-row-bg: #ffffff;
   --t-row-bg-alt: #f7f7f7;
   --t-row-bg-hover: #f5f5f5;
-  --t-row-bg-group: #e8f3fb;
-  --t-row-bg-sub: #e0ecf7;
+  --t-row-bg-group: #e0ecf7;
+  --t-row-bg-sub: #e8f3fb;
   --t-row-bg-sub-alt: #f4f9fd;
   --t-row-border: #e5e5e5;
   --t-text-primary: #1a1a1a;


### PR DESCRIPTION
## Summary

- Group header row (the collapsed "Name ×N" row) gets the darker shade, making it more visually prominent as the parent
- Sub-rows get the lighter base color, with the existing alt color for zebra striping
- Applies to both Clean and Whiskey Bar themes