### PR TITLE
feat: bracket expanded groups with top and bottom borders

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -180,7 +180,7 @@
           <tbody x-data="{ open: false }" class="{{ 'stripe' if loop.index is even else '' }}">
 
             {# Group header row #}
-            <tr class="group-row" @click="open = !open">
+            <tr class="group-row" @click="open = !open" :class="open ? 'group-open' : ''">
 
               {% if is_my_list %}<td></td>{% endif %}
 

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -335,6 +335,10 @@ ul.terms li {
   user-select: none;
 }
 
+.themed-table .group-row.group-open {
+  border-top: 2px solid rgba(0, 0, 0, 0.35) !important;
+}
+
 .themed-table .group-row:hover {
   filter: brightness(0.97);
 }


### PR DESCRIPTION
## Summary

- Adds a `2px solid rgba(0,0,0,0.35)` top border to the group header row when expanded, matching the existing bottom border on the last sub-row
- Uses Alpine `:class` binding (`group-open`) so the top border only appears when the group is open
- Together, the top and bottom borders visually bracket the expanded group, balancing the separator