### PR TITLE
feat: extend bottle search to match description, bottler, and distillery

### DIFF
--- a/mywhiskies/services/bottle/bottle.py
+++ b/mywhiskies/services/bottle/bottle.py
@@ -85,7 +85,13 @@ def list_bottles_by_user(
 
     if q:
         q_lower = q.lower()
-        bottles = [b for b in bottles if q_lower in b.name.lower()]
+        bottles = [
+            b for b in bottles
+            if q_lower in b.name.lower()
+            or (b.description and q_lower in b.description.lower())
+            or (b.bottler and q_lower in b.bottler.name.lower())
+            or any(q_lower in d.name.lower() for d in b.distilleries)
+        ]
 
     groups = _make_groups(bottles)
     groups.sort(
@@ -137,7 +143,13 @@ def list_bottles_for_entity(
 
     if q:
         q_lower = q.lower()
-        bottles = [b for b in bottles if q_lower in b.name.lower()]
+        bottles = [
+            b for b in bottles
+            if q_lower in b.name.lower()
+            or (b.description and q_lower in b.description.lower())
+            or (b.bottler and q_lower in b.bottler.name.lower())
+            or any(q_lower in d.name.lower() for d in b.distilleries)
+        ]
 
     groups = _make_groups(bottles)
     groups.sort(
@@ -173,7 +185,13 @@ def get_random_bottle(
         bottles = [b for b in bottles if b.type.name in types]
     if q:
         q_lower = q.lower()
-        bottles = [b for b in bottles if q_lower in b.name.lower()]
+        bottles = [
+            b for b in bottles
+            if q_lower in b.name.lower()
+            or (b.description and q_lower in b.description.lower())
+            or (b.bottler and q_lower in b.bottler.name.lower())
+            or any(q_lower in d.name.lower() for d in b.distilleries)
+        ]
     return random.choice(bottles) if bottles else None
 
 

--- a/tests/unit/bottle/test_bottle_service.py
+++ b/tests/unit/bottle/test_bottle_service.py
@@ -36,6 +36,29 @@ def test_list_bottles_search(test_user_01: User) -> None:
     assert all(first_name in b.name.lower() for b in all_bottles)
 
 
+def test_list_bottles_search_by_description(test_user_01: User) -> None:
+    data = list_bottles_by_user(user=test_user_01, is_my_list=True, q="fallon-grown")
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert len(all_bottles) == 1
+    assert "fallon-grown" in all_bottles[0].description.lower()
+
+
+def test_list_bottles_search_by_bottler(test_user_01: User) -> None:
+    data = list_bottles_by_user(user=test_user_01, is_my_list=True, q="lost lantern")
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert len(all_bottles) >= 1
+    assert all(b.bottler and "lost lantern" in b.bottler.name.lower() for b in all_bottles)
+
+
+def test_list_bottles_search_by_distillery(test_user_01: User) -> None:
+    data = list_bottles_by_user(user=test_user_01, is_my_list=True, q="ironroot")
+    all_bottles = [b for g in data["grouped"] for b in g["bottles"]]
+    assert len(all_bottles) >= 1
+    assert all(
+        any("ironroot" in d.name.lower() for d in b.distilleries) for b in all_bottles
+    )
+
+
 def test_list_bottles_type_filter(test_user_01: User) -> None:
     data = list_bottles_by_user(
         user=test_user_01, is_my_list=True, types=[BottleTypes.BOURBON.name]


### PR DESCRIPTION
## Summary

- Search query now filters against `description`, bottler name, and distillery names in addition to bottle name
- Also applies to `list_bottles_for_entity` and `get_random_bottle` for consistency
- No HTML changes needed — search is server-side via HTMX, not client-side DataTables

## Test plan

- [ ] Added unit tests for search by description, bottler, and distillery — all 14 tests pass
- [ ] Manually verify: typing a distillery name (e.g. "Lost Lantern") in the search box returns matching bottles