### PR TITLE
Drag-and-drop image dropzone + carousel UX improvements

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_image_dropzone.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_image_dropzone.html
@@ -1,0 +1,223 @@
+{#
+  Image drop-zone partial — {% include %} inside bottle add/edit forms.
+
+  Required context variables:
+    existing_images  — list of BottleImage objects in sequence order ([] on add)
+    img_s3_url       — S3 image base URL
+    form             — WTForms form object (BottleAddForm / BottleEditForm)
+    config           — Flask app config (auto-injected by Flask)
+#}
+
+<div class="mb-3">
+  <div class="mb-2">
+    <span class="fw-bold">Images</span>
+    <span class="text-muted small ms-2">Up to 3 · max {{ config.MAX_FILE_UPLOAD_MB }}MB each · JPG or PNG · drag to reorder</span>
+  </div>
+
+  <div id="dropzone-error" class="alert alert-danger py-2 mb-2 d-none" role="alert"></div>
+
+  <div id="dropzone-container" class="image-dropzone d-flex flex-wrap gap-3 align-items-start">
+
+    {% for img in existing_images %}
+      <div class="dropzone-card" data-type="existing" data-id="{{ img.id }}">
+        <img src="{{ img_s3_url }}/{{ img.bottle_id }}_{{ img.sequence }}.jpg"
+             alt="Image {{ img.sequence }}"
+             onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ img.bottle_id }}_{{ img.sequence }}.png';">
+        <button type="button" class="btn btn-danger btn-remove" title="Remove">
+          <i class="bi bi-x"></i>
+        </button>
+        <span class="seq-badge"><i class="bi bi-grip-vertical"></i></span>
+      </div>
+    {% endfor %}
+
+    <div id="dropzone-add-card" class="dropzone-add-card{% if existing_images | length >= 3 %} d-none{% endif %}">
+      <i class="bi bi-plus-circle fs-2 mb-1"></i>
+      <small class="text-center px-2">Drop image here<br>or click to browse</small>
+    </div>
+
+  </div>
+
+  <div class="mt-2 small text-muted">
+    Portrait-oriented images <i class="bi bi-file-image"></i> are preferred.
+    By uploading images you agree to the
+    <a href="" data-bs-toggle="modal" data-bs-target="#imageTerms">Image Terms and Conditions</a>.
+  </div>
+</div>
+
+{# Hidden file inputs — populated by JS on submit via DataTransfer #}
+<div class="d-none">
+  {{ form.bottle_image_1(id="bottle_image_1", accept=".jpg,.jpeg,.png") }}
+  {{ form.bottle_image_2(id="bottle_image_2", accept=".jpg,.jpeg,.png") }}
+  {{ form.bottle_image_3(id="bottle_image_3", accept=".jpg,.jpeg,.png") }}
+  {# Shared browse picker — no name, does not submit #}
+  <input type="file" id="dropzone-picker" accept=".jpg,.jpeg,.png" multiple>
+</div>
+
+{{ form.image_order(id="image_order") }}
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+<script>
+(function () {
+  'use strict';
+
+  const MAX_BYTES = {{ config.MAX_FILE_UPLOAD_BYTES }};
+  const MAX_MB   = {{ config.MAX_FILE_UPLOAD_MB }};
+  const MAX_IMGS  = 3;
+
+  const zone     = document.getElementById('dropzone-container');
+  const addCard  = document.getElementById('dropzone-add-card');
+  const errorEl  = document.getElementById('dropzone-error');
+  const picker   = document.getElementById('dropzone-picker');
+  const orderFld = document.getElementById('image_order');
+
+  // slot (1–3) → File object for pending new uploads
+  const pending = {};
+
+  // ── SortableJS ────────────────────────────────────────────────────────────
+  Sortable.create(zone, {
+    animation: 150,
+    filter: '#dropzone-add-card',
+    preventOnFilter: false,
+    ghostClass: 'sortable-ghost',
+    dragClass: 'sortable-drag',
+    onEnd: () => { serializeOrder(); updateAddCard(); }
+  });
+
+  serializeOrder();
+  updateAddCard();
+
+  // ── Drag image files from the filesystem ─────────────────────────────────
+  zone.addEventListener('dragenter', e => {
+    if (hasFiles(e)) zone.classList.add('dragover');
+  });
+  zone.addEventListener('dragover', e => {
+    if (hasFiles(e)) { e.preventDefault(); zone.classList.add('dragover'); }
+  });
+  zone.addEventListener('dragleave', e => {
+    if (!zone.contains(e.relatedTarget)) zone.classList.remove('dragover');
+  });
+  zone.addEventListener('drop', e => {
+    e.preventDefault();
+    zone.classList.remove('dragover');
+    if (!hasFiles(e)) return;
+    const room = MAX_IMGS - cardCount();
+    Array.from(e.dataTransfer.files).slice(0, room).forEach(addFile);
+  });
+
+  // ── Click the add card to open a file picker ──────────────────────────────
+  addCard.addEventListener('click', () => picker.click());
+  picker.addEventListener('change', () => {
+    const room = MAX_IMGS - cardCount();
+    Array.from(picker.files).slice(0, room).forEach(addFile);
+    picker.value = '';
+  });
+
+  // ── Remove button ─────────────────────────────────────────────────────────
+  zone.addEventListener('click', e => {
+    const btn = e.target.closest('.btn-remove');
+    if (!btn) return;
+    const card = btn.closest('.dropzone-card');
+    if (!card) return;
+    if (card.dataset.type === 'new') {
+      const s = +card.dataset.slot;
+      delete pending[s];
+      const inp = document.getElementById('bottle_image_' + s);
+      if (inp) inp.value = '';
+    }
+    card.remove();
+    serializeOrder();
+    updateAddCard();
+  });
+
+  // ── On submit: move File objects into the named inputs via DataTransfer ───
+  zone.closest('form').addEventListener('submit', () => {
+    serializeOrder();
+    for (const [slot, file] of Object.entries(pending)) {
+      const inp = document.getElementById('bottle_image_' + slot);
+      if (!inp || !file) continue;
+      try {
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        inp.files = dt.files;
+      } catch (err) {
+        console.warn('DataTransfer not supported:', err);
+      }
+    }
+  });
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  function hasFiles(e) {
+    return e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files');
+  }
+
+  function cardCount() {
+    return zone.querySelectorAll('.dropzone-card').length;
+  }
+
+  function nextSlot() {
+    for (let s = 1; s <= MAX_IMGS; s++) if (!pending[s]) return s;
+    return null;
+  }
+
+  function updateAddCard() {
+    addCard.classList.toggle('d-none', cardCount() >= MAX_IMGS);
+  }
+
+  function showError(msg) {
+    errorEl.textContent = msg;
+    errorEl.classList.remove('d-none');
+    clearTimeout(showError._t);
+    showError._t = setTimeout(() => errorEl.classList.add('d-none'), 6000);
+  }
+
+  function serializeOrder() {
+    const order = [];
+    zone.querySelectorAll('.dropzone-card').forEach(c => {
+      if (c.dataset.type === 'existing') {
+        order.push({ type: 'existing', id: c.dataset.id });
+      } else if (c.dataset.type === 'new') {
+        order.push({ type: 'new', slot: +c.dataset.slot });
+      }
+    });
+    orderFld.value = JSON.stringify(order);
+  }
+
+  function addFile(file) {
+    if (cardCount() >= MAX_IMGS) return;
+    if (!file.type.match(/^image\/(jpeg|png)$/)) {
+      showError('"' + file.name + '" — unsupported type. Use JPG or PNG.');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      showError('"' + file.name + '" exceeds the ' + MAX_MB + 'MB limit.');
+      return;
+    }
+    const slot = nextSlot();
+    if (!slot) return;
+    pending[slot] = file;
+
+    const reader = new FileReader();
+    reader.onload = ev => {
+      const card = buildCard(slot, ev.target.result, file.name);
+      zone.insertBefore(card, addCard);
+      serializeOrder();
+      updateAddCard();
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function buildCard(slot, src, alt) {
+    const d = document.createElement('div');
+    d.className = 'dropzone-card';
+    d.dataset.type = 'new';
+    d.dataset.slot = slot;
+    d.innerHTML =
+      '<img src="' + src + '" alt="' + alt + '">' +
+      '<button type="button" class="btn btn-danger btn-remove" title="Remove">' +
+        '<i class="bi bi-x"></i>' +
+      '</button>' +
+      '<span class="seq-badge"><i class="bi bi-grip-vertical"></i></span>';
+    return d;
+  }
+})();
+</script>

--- a/mywhiskies/blueprints/bottle/templates/bottle/add.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/add.html
@@ -44,17 +44,7 @@
 
           <hr class="my-4" />
 
-          <div class="mb-2 pb-2 text-nowrap">
-            Upload up to 3 images. Portrait-oriented images (<i class="bi bi-file-image"></i>) are preferred.
-            <br />
-            <span class="fw-bold">Maximum file size per image: {{ config.MAX_FILE_UPLOAD_MB }}MB.</span>
-            <br />
-            By uploading images I agree to the <a href="" data-bs-toggle="modal" data-bs-target="#imageTerms">Image Terms and Conditions.</a>
-          </div>
-
-          {{ form_utils.render_filefield(form.bottle_image_1, 1) }}
-          {{ form_utils.render_filefield(form.bottle_image_2, 2) }}
-          {{ form_utils.render_filefield(form.bottle_image_3, 3) }}
+          {% include "bottle/_image_dropzone.html" %}
 
           <div class="pt-3 mb-3">
             {{ form.submit(class="btn btn-primary") }}
@@ -94,57 +84,4 @@
       </div>
     </div>
   </div>
-{% endblock %}
-
-{% block scripts %}
-  {{ super() }}
-  <script>
-    const MAX_BYTES = {{ config.MAX_FILE_UPLOAD_BYTES }};
-
-    document.addEventListener("change", (e) => {
-      const input = e.target;
-
-      if (!input.matches('input[type="file"][name^="bottle_image_"]')) {
-        return;
-      }
-
-      const file = input.files && input.files[0];
-      const tooLarge = !!file && file.size > MAX_BYTES;
-
-      // turn field red
-      input.classList.toggle("is-invalid", tooLarge);
-
-      // ensure it's visible even if file input styling is weird
-      input.classList.toggle("border", tooLarge);
-      input.classList.toggle("border-danger", tooLarge);
-
-      // force the feedback to show/hide
-      const feedback = input.parentElement.querySelector(".invalid-feedback");
-      if (feedback) {
-        feedback.classList.toggle("d-block", tooLarge);
-      }
-    });
-
-    // Clear button cleanup
-    document.addEventListener("click", (e) => {
-      const btn = e.target.closest(".clear-image-btn");
-      if (!btn) return;
-
-      // Button id looks like: clear-bottle_image_1
-      const fieldId = btn.id.replace("clear-", "");
-      const input = document.getElementById(fieldId);
-      if (!input) return;
-
-      // Clear the file input
-      input.value = "";
-
-      // Remove validation styling
-      input.classList.remove("is-invalid", "border", "border-danger");
-
-      const feedback = input.parentElement.querySelector(".invalid-feedback");
-      if (feedback) {
-        feedback.classList.remove("d-block");
-      }
-    });
-  </script>
 {% endblock %}

--- a/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
@@ -166,38 +166,54 @@
           {% if bottle.image_count %}
           <div class="col-lg-6 d-flex justify-content-lg-end justify-content-start pe-0">
             {% if bottle.image_count > 1 %}
-            <div class="me-0" style="max-width:350px;">
-              <div id="bottleCarousel" class="carousel carousel-dark slide carousel-fade float-lg-end" data-bs-ride="false" data-bs-interval="false" data-bs-touch="true">
-                <div class="carousel-indicators">
-                  {% for n in range(1, bottle.image_count + 1) %}
-                    <button type="button" data-bs-target="#bottleCarousel" data-bs-slide-to="{{ n-1 }}"{% if n == 1 %} class="active" aria-current="true"{% endif %} aria-label="Slide {{ n }}"></button>
-                  {% endfor %}
-                </div>
+            <div class="bottle-image-panel">
+              <div id="bottleCarousel" class="carousel slide carousel-fade" data-bs-ride="false" data-bs-interval="false" data-bs-touch="true">
                 <div class="carousel-inner">
                   {% for n in range(1, bottle.image_count + 1) %}
                     <div class="carousel-item{% if n == 1 %} active{% endif %}">
-<img
-  alt="{{ bottle.name }}"
-  title="{{ bottle.name }}"
-  class="bottle-img rounded border border-2 border-dark d-block w-100"
-  src="{{img_s3_url}}/{{ bottle.id }}_{{ n }}.jpg"
-  onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_{{ n }}.png';"
-/>
+                      <img
+                        alt="{{ bottle.name }}"
+                        title="{{ bottle.name }}"
+                        class="bottle-img d-block w-100"
+                        src="{{img_s3_url}}/{{ bottle.id }}_{{ n }}.jpg"
+                        onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_{{ n }}.png';"
+                      />
                     </div>
                   {% endfor %}
-                  <button class="carousel-control-prev" type="button" data-bs-target="#bottleCarousel" data-bs-slide="prev">
-                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                    <span class="visually-hidden">Previous</span>
-                  </button>
-                  <button class="carousel-control-next" type="button" data-bs-target="#bottleCarousel" data-bs-slide="next">
-                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                    <span class="visually-hidden">Next</span>
-                  </button>
                 </div>
               </div>
+              <div class="d-flex justify-content-between align-items-center mt-1 pt-2 border-top border-light">
+                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-target="#bottleCarousel" data-bs-slide="prev">
+                  <i class="bi bi-chevron-left"></i> Prev
+                </button>
+                <div class="d-flex gap-2 align-items-center">
+                  {% for n in range(1, bottle.image_count + 1) %}
+                    <button type="button"
+                            class="carousel-dot{% if n == 1 %} active{% endif %}"
+                            data-bs-target="#bottleCarousel"
+                            data-bs-slide-to="{{ n - 1 }}"
+                            aria-label="Image {{ n }}"
+                            {% if n == 1 %}aria-current="true"{% endif %}></button>
+                  {% endfor %}
+                </div>
+                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-target="#bottleCarousel" data-bs-slide="next">
+                  Next <i class="bi bi-chevron-right"></i>
+                </button>
+              </div>
+              <script>
+                (function () {
+                  const el = document.getElementById('bottleCarousel');
+                  const dots = document.querySelectorAll('.carousel-dot');
+                  el.addEventListener('slide.bs.carousel', e => {
+                    dots.forEach((d, i) => d.classList.toggle('active', i === e.to));
+                  });
+                })();
+              </script>
             </div>
             {% else %}
-              <img alt="{{ bottle.name }}" title="{{ bottle.name }}" class="bottle-img rounded border border-2 border-dark" src="{{img_s3_url}}/{{ bottle.id }}_1.jpg" onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_1.png';" />
+              <div class="bottle-image-panel">
+                <img alt="{{ bottle.name }}" title="{{ bottle.name }}" class="bottle-img w-100" src="{{img_s3_url}}/{{ bottle.id }}_1.jpg" onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_1.png';" />
+              </div>
             {% endif %}
           </div>
           {% endif %}

--- a/mywhiskies/blueprints/bottle/templates/bottle/edit.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/edit.html
@@ -20,11 +20,6 @@
           
           {{ form.csrf_token }}
 
-          {# Hidden fields for image removal tracking #}
-          {{ form.remove_image_1() }}
-          {{ form.remove_image_2() }}
-          {{ form.remove_image_3() }}
-        
           {{ form_utils.render_field(form.name) }}
           {{ form_utils.render_field(form.url) }}
           {{ form_utils.render_field(form.distilleries) }}
@@ -47,25 +42,7 @@
 
           <hr class="my-4" />
 
-          <div class="mb-2 pb-2">
-            <p class="text-nowrap">
-              Upload up to 3 images. Portrait-oriented images are preferred. <i class="bi bi-file-image"></i>
-            </p>
-            <small>
-              By uploading images I agree to the <a href="" data-bs-toggle="modal" data-bs-target="#imageTerms">Image Terms and Conditions.</a>
-            </small>
-          </div>
-
-{% for n in range(1, 4) %}
-    {{ form_utils.render_filefield(
-        form["bottle_image_" ~ n], 
-        n, 
-        img_s3_url=img_s3_url, 
-        bottle_id=bottle.id, 
-        image_exists=(images[n - 1] is not none)
-    ) }}
-    {{ form["remove_image_" ~ n]() }} <!-- Hidden field for image removal tracking -->
-{% endfor %}
+          {% include "bottle/_image_dropzone.html" %}
 
           <div class="pt-3 mb-3">
             {{ form.submit(class="btn btn-primary") }}

--- a/mywhiskies/blueprints/bottle/views/bottle.py
+++ b/mywhiskies/blueprints/bottle/views/bottle.py
@@ -147,6 +147,7 @@ def bottle_add():
         return redirect(url_for("distillery.no_distilleries"))
 
     form = prep_bottle_form(current_user, BottleAddForm())
+    _, _, img_s3_url = get_s3_config()
 
     if form.validate_on_submit():
         bottle = add_bottle(form, current_user)
@@ -157,6 +158,8 @@ def bottle_add():
         "bottle/add.html",
         title=f"{current_user.username}'s Whiskies: Add Bottle",
         form=form,
+        img_s3_url=img_s3_url,
+        existing_images=[],
     )
 
 
@@ -173,10 +176,6 @@ def bottle_edit(username: str, user_num: int):
     _bottle = db.one_or_404(db.select(Bottle).filter_by(user_id=user.id, user_num=user_num))
     _, _, img_s3_url = get_s3_config()
 
-    images = [None] * 3
-    for img in _bottle.images:
-        images[img.sequence - 1] = img
-
     form = prep_bottle_form(current_user, BottleEditForm(obj=_bottle))
     if form.validate_on_submit():
         edit_bottle(form, _bottle)
@@ -191,7 +190,7 @@ def bottle_edit(username: str, user_num: int):
         bottle=_bottle,
         form=form,
         img_s3_url=img_s3_url,
-        images=images,
+        existing_images=list(_bottle.images),
     )
 
 

--- a/mywhiskies/forms/bottle.py
+++ b/mywhiskies/forms/bottle.py
@@ -160,11 +160,11 @@ class BottleAddForm(FlaskForm):
         "Image 3:", validators=[FileAllowed(["jpg", "jpeg", "png"], IMG_MESSAGE)]
     )
 
+    # Serialized JSON order from the drop zone widget; empty when JS is disabled.
+    image_order = HiddenField()
+
     submit = SubmitField("Add Bottle")
 
 
 class BottleEditForm(BottleAddForm):
-    remove_image_1 = HiddenField()
-    remove_image_2 = HiddenField()
-    remove_image_3 = HiddenField()
     submit = SubmitField("Edit Bottle")

--- a/mywhiskies/services/bottle/bottle.py
+++ b/mywhiskies/services/bottle/bottle.py
@@ -12,6 +12,7 @@ from mywhiskies.services.bottle.image import (
     add_bottle_images,
     delete_bottle_images,
     get_s3_config,
+    process_bottle_images,
 )
 
 _SORT_FNS = {
@@ -236,14 +237,14 @@ def add_bottle(form: BottleAddForm, user: User) -> Bottle:
     db.session.add(bottle)
     db.session.commit()
 
-    # Upload images
-    if add_bottle_images(form, bottle):
+    ok, error = process_bottle_images(form, bottle)
+    if ok:
         flash(f'"{bottle.name}" has been successfully added.', "success")
     else:
         db.session.delete(bottle)
         db.session.commit()
-        flash(f'An error occurred while creating "{bottle.name}".', "danger")
-        return None  # Bottle creation failed
+        flash(error or f'An error occurred while creating "{bottle.name}".', "danger")
+        return None
 
     current_app.logger.info(f"{user.username} added bottle {bottle.name} successfully.")
     return bottle
@@ -255,14 +256,10 @@ def edit_bottle(form: BottleEditForm, bottle: Bottle) -> None:
     db.session.add(bottle)
     db.session.commit()
 
-    # Handle image removals - resequencing is handled in delete_bottle_images
-    for seq in range(1, 4):
-        if getattr(form, f"remove_image_{seq}").data == "YES":
-            if image := bottle.get_image_by_sequence(seq):
-                delete_bottle_images(bottle, [image.id])
-
-    # Handle new image uploads - add_bottle_images will maintain proper sequencing
-    add_bottle_images(form, bottle)
+    ok, error = process_bottle_images(form, bottle)
+    if not ok:
+        flash(error or f'An error occurred while updating images for "{bottle.name}".', "danger")
+        return
 
     flash(f'"{bottle.name}" has been successfully updated.', "success")
     current_app.logger.info(

--- a/mywhiskies/services/bottle/image.py
+++ b/mywhiskies/services/bottle/image.py
@@ -118,10 +118,14 @@ def process_bottle_images(form, bottle: Bottle) -> Tuple[bool, Optional[str]]:
                     Bucket=img_s3_bucket,
                     Key=f"{img_s3_key}/{bottle.id}_tmp_{new_seq}.jpg",
                 )
-                s3_client.delete_object(
-                    Bucket=img_s3_bucket,
-                    Key=f"{img_s3_key}/{bottle.id}_{old_seq}.jpg",
-                )
+            # Phase 3: delete old keys that are not a final destination of any rename.
+            final_seqs_set = {new_seq for _, new_seq in to_rename.values()}
+            for _, (old_seq, _) in to_rename.items():
+                if old_seq not in final_seqs_set:
+                    s3_client.delete_object(
+                        Bucket=img_s3_bucket,
+                        Key=f"{img_s3_key}/{bottle.id}_{old_seq}.jpg",
+                    )
 
         # DB: reassign sequences (temp offset avoids UNIQUE constraint conflicts).
         for img in kept.values():

--- a/mywhiskies/services/bottle/image.py
+++ b/mywhiskies/services/bottle/image.py
@@ -1,4 +1,6 @@
 import io
+import json
+from typing import Optional, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
@@ -17,6 +19,142 @@ def get_s3_config():
         current_app.config["BOTTLE_IMAGE_S3_KEY"],
         f"{current_app.config['BOTTLE_IMAGE_S3_URL']}/{current_app.config['BOTTLE_IMAGE_S3_KEY']}",
     )
+
+
+def process_bottle_images(form, bottle: Bottle) -> Tuple[bool, Optional[str]]:
+    """
+    Process the drop-zone form submission: parse `image_order` JSON and apply
+    uploads, reordering, and removals in one atomic operation.
+
+    Falls back to `add_bottle_images` when `image_order` is empty (JS disabled).
+
+    Returns (True, None) on success, (False, error_message) on failure.
+    """
+    image_order_field = getattr(form, "image_order", None)
+    image_order_str = (image_order_field.data or "").strip() if image_order_field else ""
+
+    if not image_order_str:
+        # JS-disabled fallback: process bottle_image_1/2/3 in slot order.
+        ok = add_bottle_images(form, bottle)
+        return (True, None) if ok else (False, "An error occurred while uploading images.")
+
+    try:
+        image_order = json.loads(image_order_str)
+    except (json.JSONDecodeError, ValueError):
+        return False, "Invalid image order data."
+
+    if not image_order:
+        return True, None
+
+    # Server-side file-size validation before touching anything.
+    max_bytes = current_app.config.get("MAX_FILE_UPLOAD_BYTES", 10 * 1024 * 1024)
+    max_mb = current_app.config.get("MAX_FILE_UPLOAD_MB", 10)
+    for item in image_order:
+        if item.get("type") == "new":
+            slot = item.get("slot")
+            if slot:
+                ff = getattr(form, f"bottle_image_{slot}", None)
+                if ff and ff.data:
+                    ff.data.seek(0, 2)
+                    size = ff.data.tell()
+                    ff.data.seek(0)
+                    if size > max_bytes:
+                        return False, f"One or more images exceed the {max_mb}MB size limit."
+
+    s3_client = boto3.client("s3")
+    img_s3_bucket, img_s3_key, _ = get_s3_config()
+
+    # Build map of current existing images.
+    existing_map = {img.id: img for img in bottle.images}
+    keep_ids = {
+        item["id"]
+        for item in image_order
+        if item.get("type") == "existing" and item.get("id")
+    }
+
+    # Delete images that are no longer in the order.
+    for img_id, img in list(existing_map.items()):
+        if img_id not in keep_ids:
+            try:
+                s3_client.delete_object(
+                    Bucket=img_s3_bucket,
+                    Key=f"{img_s3_key}/{bottle.id}_{img.sequence}.jpg",
+                )
+            except ClientError:
+                pass  # Non-fatal; DB record still cleaned up.
+            db.session.delete(img)
+    db.session.flush()
+
+    kept = {img_id: img for img_id, img in existing_map.items() if img_id in keep_ids}
+    orig_seqs = {img_id: img.sequence for img_id, img in kept.items()}
+
+    # Compute final sequences for kept existing images.
+    final_seqs: dict = {}
+    for final_seq, item in enumerate(image_order, start=1):
+        if item.get("type") == "existing" and item.get("id") in kept:
+            final_seqs[item["id"]] = final_seq
+
+    try:
+        # S3: rename existing images whose sequence changes (two-phase to avoid conflicts).
+        to_rename = {
+            img_id: (orig_seqs[img_id], new_seq)
+            for img_id, new_seq in final_seqs.items()
+            if orig_seqs[img_id] != new_seq
+        }
+        if to_rename:
+            for img_id, (old_seq, new_seq) in to_rename.items():
+                s3_client.copy_object(
+                    Bucket=img_s3_bucket,
+                    CopySource=f"{img_s3_bucket}/{img_s3_key}/{bottle.id}_{old_seq}.jpg",
+                    Key=f"{img_s3_key}/{bottle.id}_tmp_{new_seq}.jpg",
+                )
+            for img_id, (old_seq, new_seq) in to_rename.items():
+                s3_client.copy_object(
+                    Bucket=img_s3_bucket,
+                    CopySource=f"{img_s3_bucket}/{img_s3_key}/{bottle.id}_tmp_{new_seq}.jpg",
+                    Key=f"{img_s3_key}/{bottle.id}_{new_seq}.jpg",
+                )
+                s3_client.delete_object(
+                    Bucket=img_s3_bucket,
+                    Key=f"{img_s3_key}/{bottle.id}_tmp_{new_seq}.jpg",
+                )
+                s3_client.delete_object(
+                    Bucket=img_s3_bucket,
+                    Key=f"{img_s3_key}/{bottle.id}_{old_seq}.jpg",
+                )
+
+        # DB: reassign sequences (temp offset avoids UNIQUE constraint conflicts).
+        for img in kept.values():
+            img.sequence = 10 + img.sequence
+            db.session.flush()
+        for img_id, new_seq in final_seqs.items():
+            kept[img_id].sequence = new_seq
+            db.session.flush()
+
+        # Upload new images at their final positions.
+        for final_seq, item in enumerate(image_order, start=1):
+            if item.get("type") == "new":
+                slot = item.get("slot")
+                if slot:
+                    ff = getattr(form, f"bottle_image_{slot}", None)
+                    if ff and ff.data:
+                        jpg_bytes = _to_resized_jpg_bytes(ff.data)
+                        s3_client.put_object(
+                            Body=jpg_bytes,
+                            Bucket=img_s3_bucket,
+                            Key=f"{img_s3_key}/{bottle.id}_{final_seq}.jpg",
+                            ContentType="image/jpeg",
+                            CacheControl="public, max-age=31536000",
+                        )
+                        db.session.add(BottleImage(bottle_id=bottle.id, sequence=final_seq))
+                        db.session.flush()
+
+        db.session.commit()
+        return True, None
+
+    except (ClientError, OSError, ValueError):
+        db.session.rollback()
+        return False, "An error occurred while uploading images."
 
 
 def add_bottle_images(form: BottleAddForm, bottle: Bottle) -> bool:

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -69,64 +69,55 @@ a:focus, a:hover {
   margin-top: 0;
 }
 
+/* bottle image panel — wraps carousel (or single image) + controls */
+.bottle-image-panel {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 2rem;
+  border: 1px solid #e8e8e8;
+  border-radius: 6px;
+  background: #fafafa;
+}
+
 /* bottle image on bottle detail page */
 .bottle-img {
   max-height: 100%;
   max-width: 100%;
   margin: auto;
+  border-radius: 4px;
+}
+
+/* Fixed-height carousel so prev/next buttons stay anchored regardless of image dimensions */
+#bottleCarousel .carousel-inner {
+  height: 400px;
+}
+#bottleCarousel .bottle-img {
+  height: 100%;
+  object-fit: contain;
+}
+
+.carousel.slide {
+  width: 100%;
+  max-width: 100%;
+}
+
+.carousel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: #ccc;
+  padding: 0;
+  transition: background-color 0.2s;
+  cursor: pointer;
+}
+.carousel-dot.active {
+  background: #6c757d;
 }
 
 /* alerts */
 /* ---------------------------------------------------------------------------------------- */
 .alert ul { margin-bottom: 0px; }
-
-
-
-#bottleCarousel {
-  margin-bottom: 40px;
-}
-
-.carousel.slide {
-    width: 100%;
-    max-width: 400px !important;
-}
-
-.carousel-indicators {
-  bottom: -50px;
-}
-
-.carousel .carousel-indicators button {
-  height: 10px;
-  width: 10px;
-  border-radius: 50%;
-}
-
-.carousel .carousel-indicators button {background-color: #808080;}
-.carousel .carousel-indicators button.active {background-color: #696969;}
-
-.carousel .carousel-control-next, .carousel .carousel-control-prev {
-  background: #FAF9F6;
-  width: 35px;
-  height: 35px;
-  border-radius: 50%;
-  top: 45%;
-}
-.carousel .carousel-control-next {
-  right: 14px;
-}
-.carousel .carousel-control-prev {
-  left: 14px;
-}
-.carousel .carousel-control-next-icon {
-  height: 20px;
-  width: 20px;
-  margin-right: -4px;
-}
-.carousel .carousel-control-prev-icon {
-  height: 20px;
-  width: 20px;
-  margin-left: -4px;
-}
 ul.terms li {
   margin-left: 24px;
 }

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -179,19 +179,97 @@ ul.terms li {
 }
 
 
-.image-preview {
-  width: 150px;  /* Match the size on the "Add" page */
-  height: 180px;
-  object-fit: cover; /* Ensures the image is cropped rather than stretched */
-  border: 1px solid #ddd;
-  border-radius: 5px;
+/* ===================================================================
+   IMAGE DROP ZONE
+   =================================================================== */
+
+.image-dropzone {
+  min-height: 210px;
+  border: 2px dashed #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
-.image-preview:hover {
-  transform: scale(1.2); /* Scales the image by 20% */
-  transition: transform 0.3s ease; /* Smooth animation */
-  z-index: 10; /* Ensures the hovered image appears on top */
+.image-dropzone.dragover {
+  border-color: #0d6efd;
+  background-color: rgba(13, 110, 253, 0.05);
 }
+
+.dropzone-card {
+  position: relative;
+  width: 150px;
+  height: 180px;
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: grab;
+  user-select: none;
+  flex-shrink: 0;
+  border: 1px solid #ddd;
+}
+
+.dropzone-card:active { cursor: grabbing; }
+
+.dropzone-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.dropzone-card .btn-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.85;
+  line-height: 1;
+}
+
+.dropzone-card .btn-remove:hover { opacity: 1; }
+
+.dropzone-card .seq-badge {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 0.65rem;
+  padding: 2px 5px;
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.dropzone-add-card {
+  width: 150px;
+  height: 180px;
+  border: 2px dashed #adb5bd;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #6c757d;
+  transition: border-color 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.dropzone-add-card:hover {
+  border-color: #0d6efd;
+  color: #0d6efd;
+}
+
+.sortable-ghost { opacity: 0.35; }
+.sortable-drag  { opacity: 0.9; cursor: grabbing !important; }
 
 
 /* ===================================================================

--- a/mywhiskies/templates/scripts.html
+++ b/mywhiskies/templates/scripts.html
@@ -6,66 +6,6 @@
   const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
   const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
 
-  document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll("[id^='clear-bottle_image_']").forEach((clearBtn) => {
-      clearBtn.addEventListener("click", function () {
-        const targetId = clearBtn.id.replace("clear-bottle_image_", ""); // Extract the image number
-
-        const input = document.querySelector(`#bottle_image_${targetId}`);
-        const preview = document.querySelector(`#bottle_image_${targetId}-preview`);
-        const placeholder = document.querySelector(`#bottle_image_${targetId}-placeholder`);
-        const removeInput = document.querySelector(`#remove_image_${targetId}`);
-
-        if (input) input.value = "";
-        if (preview) {
-          preview.src = "";
-          preview.classList.add("d-none");
-        }
-        if (placeholder) placeholder.classList.remove("d-none");
-        if (removeInput) removeInput.value = "YES"; // Indicate image removal
-        clearBtn.classList.add("d-none");
-      });
-    });
-
-    // Handle new image uploads and initial state
-    for (let n = 1; n <= 3; n++) {
-      const input = document.querySelector(`#bottle_image_${n}`);
-      const preview = document.querySelector(`#bottle_image_${n}-preview`);
-      const placeholder = document.querySelector(`#bottle_image_${n}-placeholder`);
-      const removeInput = document.querySelector(`#remove_image_${n}`);
-      const clearBtn = document.querySelector(`#clear-bottle_image_${n}`);
-
-      // Show remove button if the image exists on load
-      if (removeInput && removeInput.value === "" && preview && !preview.classList.contains("d-none")) {
-        if (clearBtn) clearBtn.classList.remove("d-none");
-      }
-
-      // Handle new image uploads
-      if (input) {
-        input.addEventListener("change", function () {
-          if (this.files && this.files[0]) {
-            const reader = new FileReader();
-            reader.onload = function (e) {
-              if (preview) {
-                preview.src = e.target.result; // Update image preview
-                preview.classList.remove("d-none");
-              }
-              if (placeholder) placeholder.classList.add("d-none");
-              if (clearBtn) clearBtn.classList.remove("d-none");
-              if (removeInput) removeInput.value = ""; // Clear removal flag
-            };
-            reader.readAsDataURL(this.files[0]);
-          } else {
-            // Reset if no file is selected
-            if (preview) preview.classList.add("d-none");
-            if (placeholder) placeholder.classList.remove("d-none");
-            if (clearBtn) clearBtn.classList.add("d-none");
-          }
-        });
-      }
-    }
-  });
-
   // Persist per-page preference in a cookie
   document.addEventListener("change", e => {
     if (e.target.matches("select[name='per_page']"))

--- a/tests/unit/bottle/test_bottle_service.py
+++ b/tests/unit/bottle/test_bottle_service.py
@@ -94,12 +94,12 @@ def test_list_bottles_for_entity_hides_private_for_guests(test_user_01: User) ->
     assert all(not b.is_private for b in all_bottles)
 
 
-@patch("mywhiskies.services.bottle.bottle.add_bottle_images")
+@patch("mywhiskies.services.bottle.bottle.process_bottle_images")
 @patch("mywhiskies.services.bottle.bottle.flash")
 def test_add_bottle(
-    mock_flash: MagicMock, mock_add_bottle_images: MagicMock, test_user_01: User
+    mock_flash: MagicMock, mock_process_bottle_images: MagicMock, test_user_01: User
 ) -> None:
-    mock_add_bottle_images.return_value = True
+    mock_process_bottle_images.return_value = (True, None)
     form = MagicMock(spec=BottleAddForm)
     form.distilleries.data = [distillery.id for distillery in test_user_01.distilleries]
     form.bottler_id.data = "0"
@@ -127,15 +127,15 @@ def test_add_bottle(
     )
 
 
-@patch("mywhiskies.services.bottle.bottle.add_bottle_images")
+@patch("mywhiskies.services.bottle.bottle.process_bottle_images")
 @patch("mywhiskies.services.bottle.bottle.flash")
 def test_edit_bottle(
     mock_flash: MagicMock,
-    mock_add_bottle_images: MagicMock,
+    mock_process_bottle_images: MagicMock,
     test_user_01: User,
     test_bottle: Bottle,
 ) -> None:
-    mock_add_bottle_images.return_value = True
+    mock_process_bottle_images.return_value = (True, None)
     form = MagicMock(spec=BottleEditForm)
     form.distilleries.data = [distillery.id for distillery in test_user_01.distilleries]
     form.bottler_id.data = "0"


### PR DESCRIPTION
## Summary

- Replaces the three separate file inputs on bottle add/edit forms with a single drag-and-drop drop zone supporting up to 3 images, drag-to-reorder, remove buttons, and client + server-side 10MB cap with clear error messages
- Images are converted to JPEG and resized for web on upload (max 1600px)
- Image order is applied on form submit (not AJAX) via a hidden `image_order` JSON field; reordering and deletions are reflected in S3 and the DB atomically
- Fixes a bug in the S3 two-phase rename where deleting old keys inline could wipe a just-relocated image when multiple images shifted sequence simultaneously
- Improves the bottle detail carousel: prev/next controls move below the image into a fixed position (no more jumping with varying image dimensions), wrapped in a subtle bordered panel, with dot indicators that update as you navigate

## Test plan

- [ ] Add a bottle with 1, 2, and 3 images — verify correct S3 upload and DB sequence
- [ ] Edit a bottle: reorder images, remove one, add a new one — verify S3 and DB reflect final order
- [ ] Verify 10MB limit shows a clear error client-side and server-side
- [ ] On the bottle detail page, cycle through multiple images of different dimensions and confirm prev/next buttons don't move
- [ ] Confirm dot indicators update correctly when navigating via buttons and via dot clicks
- [ ] Run full test suite: `pytest`