### PR TITLE
Fix bottle detail page layout on mobile

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
@@ -42,7 +42,31 @@
 
         </div>
 
-        <div class="col-auto d-flex align-items-center gap-2">
+        <!-- mobile: kebab dropdown -->
+        <div class="col-auto d-sm-none">
+          <div class="dropdown">
+            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="bi bi-three-dots-vertical"></i>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% if is_my_bottle %}
+                <li><a class="dropdown-item" href="{{ url_for('bottle.edit', username=bottle.user.username, user_num=bottle.user_num, next=request.url) }}"><i class="bi bi-pencil me-2"></i>Edit</a></li>
+                <li>
+                  <a class="dropdown-item text-danger" href="#"
+                     data-bs-toggle="modal" data-bs-target="#confirmDelete"
+                     @click="deleteUrl = '{{ url_for('bottle.delete', username=bottle.user.username, user_num=bottle.user_num, next=url_for('bottle.list', username=bottle.user.username)) }}'">
+                    <i class="bi bi-trash me-2"></i>Delete
+                  </a>
+                </li>
+                <li><hr class="dropdown-divider"></li>
+              {% endif %}
+              <li><a class="dropdown-item" href="{{ url_for('bottle.list', username=bottle.user.username) }}"><i class="bi bi-list-ul me-2"></i>{{ btn_label }}</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- desktop: individual buttons -->
+        <div class="col-auto d-none d-sm-flex align-items-center gap-2">
           {% if is_my_bottle %}
             <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('bottle.edit', username=bottle.user.username, user_num=bottle.user_num, next=request.url) }}" role="button"><i class="bi bi-pencil"></i> Edit</a>
             <a href="#" class="btn btn-sm btn-outline-danger" role="button"
@@ -194,7 +218,7 @@
 
           <!--- right column (images) --->
           {% if bottle.image_count %}
-          <div class="col-lg-6 d-flex justify-content-lg-end justify-content-start pe-0">
+          <div class="col-lg-6 d-lg-flex justify-content-lg-end pe-0">
             {% if bottle.image_count > 1 %}
             <div class="bottle-image-panel">
               <div id="bottleCarousel" class="carousel slide carousel-fade" data-bs-ride="false" data-bs-interval="false" data-bs-touch="true">

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -131,10 +131,13 @@ a:focus, a:hover {
   color: #6c757d;
   vertical-align: middle;
 }
-p.page-header-line { margin: 0; font-size: 0.875rem; }
+p.page-header-line { margin: 0; font-size: 0.875rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 p.page-header-line .page-header-context,
 p.page-header-line .page-header-sep { font-size: 1em; }
 h1 { font-family: 'Cormorant Garamond', Georgia, serif; }
+@media (max-width: 575.98px) {
+  h1 { font-size: 1.9rem; }
+}
 .page-header-sep {
   font-size: 0.44em;
   font-weight: 400;


### PR DESCRIPTION
## Summary

- Breadcrumb no longer wraps across multiple lines — nowrap + ellipsis keeps it on one line
- `h1` title font size reduced on small screens to avoid excessive vertical space
- Action buttons (Edit, Delete, My List) replaced with a `⋮` kebab dropdown on mobile; desktop layout unchanged
- Image column `d-flex` scoped to `lg+` to prevent horizontal overflow on mobile

## Test plan

- [ ] Verify breadcrumb stays on one line on a narrow viewport
- [ ] Verify title renders at a comfortable size on mobile
- [ ] Verify `⋮` button appears on mobile and dropdown contains Edit, Delete (with divider), and My List
- [ ] Verify desktop still shows individual Edit / Delete / My List buttons
- [ ] Verify bottle image does not overflow horizontally on mobile