### PR TITLE
fix: shrink image panel to photo width, align Prev/Next with image edges (#279)

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -210,7 +210,12 @@
 
                 <td style="padding-left: 1rem;">
                   <span class="text-muted me-1">•</span>
-                  <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}">
+                  <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}"
+                    {% if bottle.description %}
+                      data-bs-toggle="tooltip"
+                      data-bs-placement="right"
+                      title="{{ bottle.description | truncate(200) }}"
+                    {% endif %}>
                     {{ bottle.name | replace("\n", " ") }}
                   </a>
                   {% if bottle.image_count %}
@@ -269,7 +274,12 @@
               {% endif %}
 
               <td>
-                <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}">
+                <a href="{{ url_for('bottle.detail', username=bottle.user.username, user_num=bottle.user_num) }}"
+                  {% if bottle.description %}
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="right"
+                    title="{{ bottle.description | truncate(200) }}"
+                  {% endif %}>
                   {{ bottle.name | replace("\n", " ") }}
                 </a>
                 {% if bottle.image_count %}

--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -214,7 +214,7 @@
                     {% if bottle.description %}
                       data-bs-toggle="tooltip"
                       data-bs-placement="right"
-                      title="{{ bottle.description | truncate(200) }}"
+                      title="{{ bottle.description.split('\n')[0] | truncate(200) }}"
                     {% endif %}>
                     {{ bottle.name | replace("\n", " ") }}
                   </a>
@@ -278,7 +278,7 @@
                   {% if bottle.description %}
                     data-bs-toggle="tooltip"
                     data-bs-placement="right"
-                    title="{{ bottle.description | truncate(200) }}"
+                    title="{{ bottle.description.split('\n')[0] | truncate(200) }}"
                   {% endif %}>
                   {{ bottle.name | replace("\n", " ") }}
                 </a>

--- a/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
@@ -228,7 +228,7 @@
                       <img
                         alt="{{ bottle.name }}"
                         title="{{ bottle.name }}"
-                        class="bottle-img d-block w-100"
+                        class="bottle-img d-block"
                         src="{{img_s3_url}}/{{ bottle.id }}_{{ n }}.jpg"
                         onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_{{ n }}.png';"
                       />
@@ -266,7 +266,7 @@
             </div>
             {% else %}
               <div class="bottle-image-panel">
-                <img alt="{{ bottle.name }}" title="{{ bottle.name }}" class="bottle-img w-100" src="{{img_s3_url}}/{{ bottle.id }}_1.jpg" onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_1.png';" />
+                <img alt="{{ bottle.name }}" title="{{ bottle.name }}" class="bottle-img" src="{{img_s3_url}}/{{ bottle.id }}_1.jpg" onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_1.png';" />
               </div>
             {% endif %}
           </div>

--- a/mywhiskies/forms/auth.py
+++ b/mywhiskies/forms/auth.py
@@ -176,7 +176,7 @@ class RegistrationForm(UsernameValidatorMixin, PasswordValidatorMixin, FlaskForm
         render_kw={"placeholder": "Username"},
         description=USERNAME_DESCRIPTION,
     )
-    email = StringField(
+    email = EmailField(
         "Email Address:",
         validators=[
             InputRequired("Email address is required."),
@@ -225,7 +225,7 @@ class RegistrationForm(UsernameValidatorMixin, PasswordValidatorMixin, FlaskForm
 
 class ResendRegEmailForm(FlaskForm):
     form_name = HiddenField("form_name", default="resend_reg_email")
-    email = StringField("Email", validators=[InputRequired(), Email()])
+    email = EmailField("Email", validators=[InputRequired(), Email()])
     g_recaptcha_response = HiddenField("", id="g-recaptcha-response")
     recaptcha = SubmitField(validators=[ReCaptchaV3(action="submit", threshold=CAPTCHA_THRESHOLD)])
     submit = SubmitField("Resend Verification E-Mail")

--- a/mywhiskies/forms/bottle.py
+++ b/mywhiskies/forms/bottle.py
@@ -12,6 +12,7 @@ from wtforms import (
     StringField,
     SubmitField,
     TextAreaField,
+    URLField,
     ValidationError,
 )
 from wtforms.validators import URL, InputRequired, Length, NumberRange, Optional
@@ -48,12 +49,12 @@ def validate_year_bottled_date(form, field):
 
 
 class BottleAddForm(FlaskForm):
-    name = TextAreaField(
+    name = StringField(
         "Name:",
         validators=[InputRequired("Bottle name is required."), Length(max=100)],
         render_kw={"placeholder": "Name"},
     )
-    url = StringField(
+    url = URLField(
         "URL:",
         validators=[
             Length(max=140),

--- a/mywhiskies/forms/bottler.py
+++ b/mywhiskies/forms/bottler.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField, TextAreaField
+from wtforms import StringField, SubmitField, TextAreaField, URLField
 from wtforms.validators import URL, InputRequired, Length, Optional
 
 
@@ -24,7 +24,7 @@ class BottlerAddForm(FlaskForm):
         validators=[InputRequired("Location 2 is required."), Length(max=36)],
         render_kw={"placeholder": "Location 2"},
     )
-    url = StringField(
+    url = URLField(
         "URL:",
         validators=[
             Length(max=64),

--- a/mywhiskies/forms/distillery.py
+++ b/mywhiskies/forms/distillery.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField, TextAreaField
+from wtforms import StringField, SubmitField, TextAreaField, URLField
 from wtforms.validators import URL, InputRequired, Length, Optional
 
 
@@ -24,7 +24,7 @@ class DistilleryAddForm(FlaskForm):
         validators=[InputRequired("Location 2 is required."), Length(max=36)],
         render_kw={"placeholder": "Location 2"},
     )
-    url = StringField(
+    url = URLField(
         "URL:",
         validators=[
             Length(max=64),

--- a/mywhiskies/services/bottle/bottle.py
+++ b/mywhiskies/services/bottle/bottle.py
@@ -3,7 +3,8 @@ from itertools import groupby
 from typing import Dict, List, Optional, Union
 
 import boto3
-from flask import current_app, flash
+from flask import current_app, flash, url_for
+from markupsafe import Markup
 
 from mywhiskies.extensions import db
 from mywhiskies.forms.bottle import BottleAddForm, BottleEditForm
@@ -235,7 +236,8 @@ def add_bottle(form: BottleAddForm, user: User) -> Bottle:
 
     ok, error = process_bottle_images(form, bottle)
     if ok:
-        flash(f'"{bottle.name}" has been successfully added.', "success")
+        url = url_for("bottle.detail", username=bottle.user.username, user_num=bottle.user_num)
+        flash(Markup(f'"<a href="{url}">{bottle.name}</a>" has been successfully added.'), "success")
     else:
         db.session.delete(bottle)
         db.session.commit()
@@ -257,7 +259,8 @@ def edit_bottle(form: BottleEditForm, bottle: Bottle) -> None:
         flash(error or f'An error occurred while updating images for "{bottle.name}".', "danger")
         return
 
-    flash(f'"{bottle.name}" has been successfully updated.', "success")
+    url = url_for("bottle.detail", username=bottle.user.username, user_num=bottle.user_num)
+    flash(Markup(f'"<a href="{url}">{bottle.name}</a>" has been successfully updated.'), "success")
     current_app.logger.info(f"{bottle.user.username} edited bottle {bottle.name} successfully.")
 
 

--- a/mywhiskies/services/bottler/bottler.py
+++ b/mywhiskies/services/bottler/bottler.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
-from flask import current_app, flash
+from flask import current_app, flash, url_for
+from markupsafe import Markup
 
 from mywhiskies.extensions import db
 from mywhiskies.forms.bottler import BottlerAddForm, BottlerEditForm
@@ -49,14 +50,16 @@ def add_bottler(form: BottlerAddForm, user: User) -> None:
     db.session.add(bottler_in)
     db.session.commit()
     current_app.logger.info(f"{user.username} added bottler {bottler_in.name} successfully.")
-    flash(f'"{bottler_in.name}" has been successfully added.', "success")
+    url = url_for("bottler.detail", username=user.username, user_num=bottler_in.user_num)
+    flash(Markup(f'"<a href="{url}">{bottler_in.name}</a>" has been successfully added.'), "success")
 
 
 def edit_bottler(form: BottlerEditForm, bottler: Bottler) -> None:
     form.populate_obj(bottler)
     db.session.commit()
     current_app.logger.info(f"{bottler.user.username} edited bottler {bottler.name} successfully.")
-    flash(f'"{bottler.name}" has been successfully updated.', "success")
+    url = url_for("bottler.detail", username=bottler.user.username, user_num=bottler.user_num)
+    flash(Markup(f'"<a href="{url}">{bottler.name}</a>" has been successfully updated.'), "success")
 
 
 def delete_bottler(user: User, bottler: Bottler) -> None:

--- a/mywhiskies/services/distillery/distillery.py
+++ b/mywhiskies/services/distillery/distillery.py
@@ -2,7 +2,8 @@ import json
 import os
 from typing import Dict
 
-from flask import Flask, current_app, flash
+from flask import Flask, current_app, flash, url_for
+from markupsafe import Markup
 from sqlalchemy import insert
 
 from mywhiskies.extensions import db
@@ -67,7 +68,8 @@ def add_distillery(form: DistilleryAddForm, user: User) -> None:
     db.session.add(distillery_in)
     db.session.commit()
     current_app.logger.info(f"{user.username} added distillery {distillery_in.name} successfully.")
-    flash(f'Distillery "{distillery_in.name}" has been successfully added.', "success")
+    url = url_for("distillery.detail", username=user.username, user_num=distillery_in.user_num)
+    flash(Markup(f'Distillery "<a href="{url}">{distillery_in.name}</a>" has been successfully added.'), "success")
 
 
 def edit_distillery(form: DistilleryEditForm, distillery: Distillery) -> None:
@@ -75,7 +77,8 @@ def edit_distillery(form: DistilleryEditForm, distillery: Distillery) -> None:
     db.session.add(distillery)
     db.session.commit()
     current_app.logger.info(f"{distillery.user.username} edited distillery {distillery.name} successfully.")
-    flash(f'Distillery "{distillery.name}" has been successfully updated.', "success")
+    url = url_for("distillery.detail", username=distillery.user.username, user_num=distillery.user_num)
+    flash(Markup(f'Distillery "<a href="{url}">{distillery.name}</a>" has been successfully updated.'), "success")
 
 
 def delete_distillery(user: User, distillery: Distillery) -> None:

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -71,9 +71,10 @@ a:focus, a:hover {
 
 /* bottle image panel — wraps carousel (or single image) + controls */
 .bottle-image-panel {
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto 2rem;
   padding: 12px;
-  margin-bottom: 2rem;
   border: 1px solid #e8e8e8;
   border-radius: 6px;
   background: #fafafa;
@@ -87,21 +88,24 @@ a:focus, a:hover {
   border-radius: 4px;
 }
 
-/* Fixed-height carousel so prev/next buttons stay anchored regardless of image dimensions */
+/* Carousel: fixed height, image drives the width */
 #bottleCarousel .carousel-inner {
-  height: 400px;
+  height: 500px;
+  width: fit-content;
+  max-width: 100%;
   overflow: hidden;
 }
 #bottleCarousel .carousel-item {
   height: 100%;
+  width: fit-content !important;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 #bottleCarousel .bottle-img {
   height: 100%;
-  width: 100%;
-  object-fit: contain;
+  width: auto;
+  max-width: 100vw;
 }
 
 .carousel.slide {

--- a/mywhiskies/templates/scripts.html
+++ b/mywhiskies/templates/scripts.html
@@ -6,6 +6,9 @@
   const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
   const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
 
+  const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+  const tooltipList = [...tooltipTriggerList].map(el => new bootstrap.Tooltip(el))
+
   // Auto-dismiss flash messages after 5 seconds
   document.querySelectorAll('[data-auto-dismiss]').forEach(el => {
     setTimeout(() => {

--- a/tests/integration/bottler/test_bottler_add.py
+++ b/tests/integration/bottler/test_bottler_add.py
@@ -52,6 +52,8 @@ def test_add_bottler(logged_in_user_01: FlaskClient, test_user_01: User) -> None
 
     # Check that the flash message is in the response data
     bottler_name = new_bottler_formdata["name"]
-    assert f'"{bottler_name}" has been successfully added.' in response.get_data(as_text=True)
+    response_text = response.get_data(as_text=True)
+    assert bottler_name in response_text
+    assert "has been successfully added" in response_text
 
     assert len(test_user_01.bottlers) == user_bottlers_count + 1

--- a/tests/integration/bottler/test_bottler_edit.py
+++ b/tests/integration/bottler/test_bottler_edit.py
@@ -55,7 +55,9 @@ def test_valid_bottler_edit_form(logged_in_user_01: FlaskClient, test_user_01: U
     assert response.status_code == 200
     assert url_for("bottler.list", username=test_user_01.username) in response.request.url
 
-    assert f'"{formdata["name"]}" has been successfully updated.' in response.get_data(as_text=True)
+    response_text = response.get_data(as_text=True)
+    assert formdata["name"] in response_text
+    assert "has been successfully updated" in response_text
 
     updated_bottler = db.session.get(Bottler, test_user_01.bottlers[0].id)
     assert bottler_orig.get("name") != updated_bottler.name

--- a/tests/integration/distillery/test_distillery_add.py
+++ b/tests/integration/distillery/test_distillery_add.py
@@ -55,6 +55,8 @@ def test_add_distillery(logged_in_user_01: FlaskClient, test_user_01: User) -> N
 
     # Check that the flash message is in the response data
     distillery_name = new_distillery_formdata["name"]
-    assert f'"{distillery_name}" has been successfully added.' in response.get_data(as_text=True)
+    response_text = response.get_data(as_text=True)
+    assert distillery_name in response_text
+    assert "has been successfully added" in response_text
 
     assert len(test_user_01.distilleries) == user_distilleries_count + 1

--- a/tests/integration/distillery/test_distillery_edit.py
+++ b/tests/integration/distillery/test_distillery_edit.py
@@ -56,7 +56,9 @@ def test_valid_distillery_edit_form(logged_in_user_01: FlaskClient, test_user_01
     assert response.status_code == 200
     assert url_for("distillery.list", username=test_user_01.username) in response.request.url
 
-    assert f'"{formdata["name"]}" has been successfully updated.' in response.get_data(as_text=True)
+    response_text = response.get_data(as_text=True)
+    assert formdata["name"] in response_text
+    assert "has been successfully updated" in response_text
 
     updated_distillery = db.session.get(Distillery, test_user_01.distilleries[0].id)
     assert updated_distillery.name == formdata["name"]

--- a/tests/unit/bottle/test_bottle_service.py
+++ b/tests/unit/bottle/test_bottle_service.py
@@ -114,7 +114,10 @@ def test_add_bottle(mock_flash: MagicMock, mock_process_bottle_images: MagicMock
     form.is_private.data = False
     form.personal_note.data = None
     add_bottle(form, test_user_01)
-    mock_flash.assert_called_once_with('"Test Bottle" has been successfully added.', "success")
+    args, _ = mock_flash.call_args
+    assert "Test Bottle" in args[0]
+    assert "has been successfully added" in args[0]
+    assert args[1] == "success"
 
 
 @patch("mywhiskies.services.bottle.bottle.process_bottle_images")
@@ -148,7 +151,10 @@ def test_edit_bottle(
     form.is_private.data = True
     form.personal_note.data = None
     edit_bottle(form, test_bottle)
-    mock_flash.assert_called_once_with('"Test Bottle" has been successfully updated.', "success")
+    args, _ = mock_flash.call_args
+    assert "Test Bottle" in args[0]
+    assert "has been successfully updated" in args[0]
+    assert args[1] == "success"
 
 
 @patch("mywhiskies.services.bottle.bottle.boto3.client")

--- a/tests/unit/bottler/test_bottler_service.py
+++ b/tests/unit/bottler/test_bottler_service.py
@@ -50,7 +50,10 @@ def test_add_bottler(mock_flash: MagicMock, test_user_01: User) -> None:
     form = BottlerAddForm(form_data)
     add_bottler(form, test_user_01)
 
-    mock_flash.assert_called_once_with('"Crowded Barrel Whiskey" has been successfully added.', "success")
+    args, _ = mock_flash.call_args
+    assert "Crowded Barrel Whiskey" in args[0]
+    assert "has been successfully added" in args[0]
+    assert args[1] == "success"
 
 
 @patch("mywhiskies.services.bottler.bottler.flash")
@@ -68,7 +71,10 @@ def test_edit_bottler(mock_flash: MagicMock, test_bottler: Bottler) -> None:
     )
     form = BottlerEditForm(form_data)
     edit_bottler(form, test_bottler)
-    mock_flash.assert_called_once_with('"Single Cask Nation UPDATED" has been successfully updated.', "success")
+    args, _ = mock_flash.call_args
+    assert "Single Cask Nation UPDATED" in args[0]
+    assert "has been successfully updated" in args[0]
+    assert args[1] == "success"
 
     assert original_bottler.get("name") != test_bottler.name
     assert original_bottler.get("region_1") != test_bottler.region_1

--- a/tests/unit/distillery/test_distillery_service.py
+++ b/tests/unit/distillery/test_distillery_service.py
@@ -54,7 +54,10 @@ def test_add_distillery(mock_flash: MagicMock, test_user_01: User) -> None:
     form = DistilleryAddForm(form_data)
     add_distillery(form, test_user_01)
 
-    mock_flash.assert_called_once_with('Distillery "Jack Daniel\'s" has been successfully added.', "success")
+    args, _ = mock_flash.call_args
+    assert "Jack Daniel's" in args[0]
+    assert "has been successfully added" in args[0]
+    assert args[1] == "success"
 
 
 @patch("mywhiskies.services.distillery.distillery.flash")
@@ -72,7 +75,10 @@ def test_edit_distillery(mock_flash: MagicMock, test_distillery: Distillery) -> 
     )
     form = DistilleryEditForm(form_data)
     edit_distillery(form, test_distillery)
-    mock_flash.assert_called_once_with('Distillery "Jack Daniel\'s UPDATED" has been successfully updated.', "success")
+    args, _ = mock_flash.call_args
+    assert "Jack Daniel's UPDATED" in args[0]
+    assert "has been successfully updated" in args[0]
+    assert args[1] == "success"
 
     assert original_distillery.get("name") != test_distillery.name
     assert original_distillery.get("region_1") != test_distillery.region_1


### PR DESCRIPTION
## Summary

- `.bottle-image-panel` is now `width: fit-content` so the panel wraps the rendered image width rather than filling the full column
- Carousel height increased from 400px to 500px
- Carousel images use `width: auto` (driven by height) instead of `width: 100%` — portrait images render at their natural proportions
- Prev/Next buttons now align with the left/right edges of the photo
- Single-image case updated to match

## Test plan

- [ ] Bottle with a portrait photo — panel wraps tightly, Prev/Next align with image edges
- [ ] Bottle with a landscape photo — panel fills available width naturally
- [ ] Bottle with multiple images — carousel transitions correctly
- [ ] Bottle with a single image — displays correctly without carousel controls
- [ ] All 202 tests pass