### PR TITLE
fix: correct carousel width so panel shrinks to image width (#279 followup)

### DIFF
--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -109,7 +109,7 @@ a:focus, a:hover {
 }
 
 .carousel.slide {
-  width: 100%;
+  width: fit-content;
   max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary

Followup to #297. The original fix didn't fully work in production because `.carousel.slide { width: 100% }` created a circular dependency:

- The carousel was `width: 100%` of the panel
- The panel was `width: fit-content` of the carousel
- Browsers resolve the circularity by expanding everything to the column width

Changed `.carousel.slide` from `width: 100%` to `width: fit-content`. The panel now correctly shrinks to wrap the rendered image, and Prev/Next buttons align with the image edges.

## Test plan

- [ ] Portrait bottle photo — panel wraps tightly, Prev/Next align with image edges
- [ ] Landscape bottle photo — panel expands naturally to image width
- [ ] Multi-image carousel transitions correctly
- [ ] Single image displays correctly
- [ ] All 202 tests pass