### PR TITLE
fix: size image panel via JS window load event (#279 v3)

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
@@ -261,13 +261,38 @@
                   el.addEventListener('slide.bs.carousel', e => {
                     dots.forEach((d, i) => d.classList.toggle('active', i === e.to));
                   });
+
+                  // Size the panel to the rendered image width so Prev/Next align with image edges.
+                  // Uses window load (not img.complete) so layout is always computed first.
+                  const panel = el.closest('.bottle-image-panel');
+                  const img = el.querySelector('.carousel-item.active .bottle-img');
+                  if (panel && img) {
+                    function fitPanel() {
+                      const w = img.offsetWidth;
+                      if (w > 0) panel.style.width = w + 'px';
+                    }
+                    window.addEventListener('load', fitPanel);
+                  }
                 })();
               </script>
             </div>
             {% else %}
-              <div class="bottle-image-panel">
-                <img alt="{{ bottle.name }}" title="{{ bottle.name }}" class="bottle-img" src="{{img_s3_url}}/{{ bottle.id }}_1.jpg" onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_1.png';" />
+              <div class="bottle-image-panel" id="singleImagePanel">
+                <img alt="{{ bottle.name }}" title="{{ bottle.name }}" class="bottle-img" id="singleBottleImg"
+                  src="{{img_s3_url}}/{{ bottle.id }}_1.jpg"
+                  onerror="this.onerror=null; this.src='{{ img_s3_url }}/{{ bottle.id }}_1.png';" />
               </div>
+              <script>
+                (function () {
+                  const panel = document.getElementById('singleImagePanel');
+                  const img = document.getElementById('singleBottleImg');
+                  function fitPanel() {
+                    const w = img.offsetWidth;
+                    if (w > 0) panel.style.width = w + 'px';
+                  }
+                  window.addEventListener('load', fitPanel);
+                })();
+              </script>
             {% endif %}
           </div>
           {% endif %}

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -71,7 +71,6 @@ a:focus, a:hover {
 
 /* bottle image panel — wraps carousel (or single image) + controls */
 .bottle-image-panel {
-  width: fit-content;
   max-width: 100%;
   margin: 0 auto 2rem;
   padding: 12px;
@@ -82,8 +81,10 @@ a:focus, a:hover {
 
 /* bottle image on bottle detail page */
 .bottle-img {
-  max-height: 100%;
+  max-height: 500px;
+  width: auto;
   max-width: 100%;
+  display: block;
   margin: auto;
   border-radius: 4px;
 }
@@ -91,13 +92,10 @@ a:focus, a:hover {
 /* Carousel: fixed height, image drives the width */
 #bottleCarousel .carousel-inner {
   height: 500px;
-  width: fit-content;
-  max-width: 100%;
   overflow: hidden;
 }
 #bottleCarousel .carousel-item {
   height: 100%;
-  width: fit-content !important;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -105,11 +103,10 @@ a:focus, a:hover {
 #bottleCarousel .bottle-img {
   height: 100%;
   width: auto;
-  max-width: 100vw;
+  max-width: 100%;
 }
 
 .carousel.slide {
-  width: fit-content;
   max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary

Third attempt at #279. Root cause of previous failures:

1. **Pure CSS `fit-content`** — Bootstrap's layout engine wins the circularity battle and expands everything to column width
2. **JS with `img.complete`** — fires during HTML parsing before layout is computed; `offsetWidth` returns 0 for cached images, so nothing gets set

**This fix**: listen on `window` `load` event instead. That fires after the full page layout is complete, so `img.offsetWidth` always returns the correct rendered width. The panel's width is then stamped directly to match.

Also simplifies the CSS — removes all the `fit-content` overrides that were fighting Bootstrap, keeping only what's needed for the 500px fixed-height carousel.

## Test plan

- [ ] Portrait photo — panel shrinks to image width, Prev/Next align with edges (hard refresh AND cached)
- [ ] Landscape photo — panel expands to image width naturally
- [ ] Multi-image carousel transitions correctly
- [ ] Single image (no carousel) panel also sized correctly
- [ ] All 202 tests pass