### PR TITLE
fix: disable new user registration

### DIFF
--- a/mywhiskies/blueprints/auth/templates/auth/login.html
+++ b/mywhiskies/blueprints/auth/templates/auth/login.html
@@ -36,7 +36,7 @@
 
       <br>
 
-      <p>New User? <a href="{{ url_for('auth.register') }}">Click to Register!</a></p>
+      <p>New User? Registrations are currently closed. Please check back soon!</p>
       <p>
         Forgot Your Password?
         <a href="{{ url_for('auth.reset_password_request') }}">Click to Reset It</a>

--- a/mywhiskies/blueprints/auth/templates/auth/register.html
+++ b/mywhiskies/blueprints/auth/templates/auth/register.html
@@ -15,6 +15,19 @@
 
       <div class="container ms-0 ps-0">
         <div class="row">
+          <div class="col-md-6 pt-4">
+            <p class="lead">Registrations are currently closed.</p>
+            <p>
+              As we work towards our first public release, we're keeping new sign-ups on hold
+              while we make sure the app is ready for everyone. Please check back soon!
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {# Registration form — hidden while registrations are closed (#300)
+      <div class="container ms-0 ps-0">
+        <div class="row">
           <div class="col-md-4 pt-4">
 
             <form method="post" id="register_form" novalidate
@@ -60,6 +73,7 @@
           </div>
         </div>
       </div>
+      #}
     </div>
   </main>
 {% endblock %}

--- a/mywhiskies/blueprints/core/templates/core/main.html
+++ b/mywhiskies/blueprints/core/templates/core/main.html
@@ -48,8 +48,8 @@
               </li>
             </ul>
             {% if not current_user.is_authenticated %}
-            <p class="pt-3 ms-2">
-              Not a member yet? <a href="{{ url_for('auth.register') }}" class="btn btn-primary ms-1 text-decoration-none" role="button">Join Us!</a>
+            <p class="pt-3 ms-2 text-muted" style="font-size: 0.9rem;">
+              Registrations are currently closed as we work towards our first public release. Please check back soon!
             </p>
             {% endif %}
           </div>

--- a/tests/integration/core/test_core.py
+++ b/tests/integration/core/test_core.py
@@ -10,8 +10,8 @@ def test_main_logged_out(client: FlaskClient) -> None:
 
     assert response.status_code == 200
     assert "My Whiskies Online" in response_data
-    # "Join Us!" register prompt is shown to unauthenticated users
-    assert "Join Us!" in response_data
+    # Registrations are closed; show a notice instead of the "Join Us!" button
+    assert "Registrations are currently closed" in response_data
 
 
 def test_main_logged_in(logged_in_user_01: FlaskClient, test_user_01: User) -> None:
@@ -20,8 +20,8 @@ def test_main_logged_in(logged_in_user_01: FlaskClient, test_user_01: User) -> N
 
     assert response.status_code == 200
     assert test_user_01.username in response_data
-    # "Join Us!" prompt is hidden from authenticated users
-    assert "Join Us!" not in response_data
+    # Closed-registrations notice is only shown to unauthenticated users
+    assert "Registrations are currently closed" not in response_data
 
 
 def test_terms(client: FlaskClient) -> None:


### PR DESCRIPTION
## Summary
- Hides the registration form on `/register` and replaces it with a "registrations are currently closed" message
- Replaces the "New User? Click to Register!" link on the login page with a plain-text notice
- Replaces the "Join Us!" button on the homepage with a muted notice for unauthenticated users
- Updates the `test_main_logged_out` test to assert the closed-registration notice instead of "Join Us!"

Closes #300

## Test plan
- [ ] Visit `/register` — form is hidden, closed notice is shown
- [ ] Visit `/login` — no register link, notice shown instead
- [ ] Visit home page logged out — "Join Us!" button gone, notice shown
- [ ] Visit home page logged in — no registration notice shown
- [ ] All tests pass