### PR TITLE
feat: rich text editor for bottle/bottler/distillery text fields (#293)

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/_bottle_rows.html
@@ -214,7 +214,7 @@
                     {% if bottle.description %}
                       data-bs-toggle="tooltip"
                       data-bs-placement="right"
-                      title="{{ bottle.description.split('\n')[0] | truncate(200) }}"
+                      title="{{ bottle.description | strip_html }}"
                     {% endif %}>
                     {{ bottle.name | replace("\n", " ") }}
                   </a>

--- a/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
@@ -166,12 +166,12 @@
                 </tr>
                 <tr>
                   <td class="text-muted text-nowrap pe-4 fw-normal">Description</td>
-                  <td>{{ bottle.description | multiline_or_dash }}</td>
+                  <td>{{ bottle.description | render_rich_text }}</td>
                 </tr>
                 {% if is_my_bottle %}
                   <tr>
                     <td class="text-muted text-nowrap pe-4 fw-normal">Personal Note</td>
-                    <td>{{ bottle.personal_note | multiline_or_dash }}</td>
+                    <td>{{ bottle.personal_note | render_rich_text }}</td>
                   </tr>
                 {% endif %}
                 <tr>
@@ -190,7 +190,7 @@
                 </tr>
                 <tr>
                   <td class="text-muted text-nowrap pe-4 fw-normal">Review</td>
-                  <td>{{ bottle.review | multiline_or_dash }}</td>
+                  <td>{{ bottle.review | render_rich_text }}</td>
                 </tr>
 
                 <!-- Timeline -->

--- a/mywhiskies/blueprints/bottle/templates/bottle/form.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/form.html
@@ -1,7 +1,13 @@
 {% extends "_base.html" %}
 
+{% block head_extra %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.css">
+{% endblock %}
+
 {% block scripts %}
   {{ super() }}
+  <script src="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.umd.min.js"></script>
+  {% include "_trix_toolbar_init.html" %}
   <script>
   (function () {
     const select = document.getElementById('distilleries');
@@ -102,7 +108,8 @@
 
     <div class="row">
       <div class="col-lg-8">
-        <form method="post" novalidate enctype="multipart/form-data">
+        <form method="post" novalidate enctype="multipart/form-data"
+              x-data @trix-file-accept.window.prevent>
           {% if next_url %}
             <input type="hidden" name="next" value="{{ next_url }}">
           {% endif %}
@@ -132,15 +139,15 @@
           <hr class="my-3" />
           <p class="text-uppercase text-muted fw-semibold mb-3" style="font-size:0.7rem; letter-spacing:0.06em;">Notes</p>
 
-          {{ form_utils.render_field(form.description) }}
-          {{ form_utils.render_field(form.personal_note, popover_text=popover_personal_note) }}
+          {{ form_utils.render_trix_field(form.description) }}
+          {{ form_utils.render_trix_field(form.personal_note, popover_text=popover_personal_note) }}
 
           <div class="row">
             <div class="col-sm-4">{{ form_utils.render_field(form.stars) }}</div>
             <div class="col-sm-4">{{ form_utils.render_field(form.cost) }}</div>
           </div>
 
-          {{ form_utils.render_field(form.review) }}
+          {{ form_utils.render_trix_field(form.review) }}
 
           <div class="d-flex gap-4 mb-1">
             {{ form_utils.render_checkbox(form.is_single_barrel) }}

--- a/mywhiskies/blueprints/bottler/templates/bottler/form.html
+++ b/mywhiskies/blueprints/bottler/templates/bottler/form.html
@@ -1,5 +1,15 @@
 {% extends "_base.html" %}
 
+{% block head_extra %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.css">
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.umd.min.js"></script>
+  {% include "_trix_toolbar_init.html" %}
+{% endblock %}
+
 {% block app_content %}
   <main class="flex-shrink-0">
     <div class="container ps-0">
@@ -20,14 +30,14 @@
 
       <div class="row">
         <div class="col-md-4">
-          <form method="post" novalidate>
+          <form method="post" novalidate x-data @trix-file-accept.window.prevent>
             {% set popover_location_1 = "<p>The first part of the bottler's location.</p><p>If the bottler is in Bardstown, KY, the value for &quot;Location 1&quot; would be <b>Bardstown</b>.</p><p>If the bottler is in Islay, Scotland, the value for &quot;Location 1&quot; would be <b>Islay</b>.</p>" %}
             {% set popover_location_2 = "<p>The second part of the bottler's location.</p><p>If the bottler is in Bardstown, KY, the value for &quot;Location 1&quot; would be <b>KY</b>.</p><p>If the bottler is in Islay, Scotland, the value for &quot;Location 1&quot; would be <b>Scotland</b>.</p>" %}
 
             {{ form.csrf_token }}
 
             {{ form_utils.render_field(form.name) }}
-            {{ form_utils.render_field(form.description) }}
+            {{ form_utils.render_trix_field(form.description) }}
             {{ form_utils.render_field(form.region_1, popover_text=popover_location_1) }}
             {{ form_utils.render_field(form.region_2, popover_text=popover_location_2) }}
             {{ form_utils.render_field(form.url) }}

--- a/mywhiskies/blueprints/distillery/templates/distillery/form.html
+++ b/mywhiskies/blueprints/distillery/templates/distillery/form.html
@@ -1,5 +1,15 @@
 {% extends "_base.html" %}
 
+{% block head_extra %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.css">
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.umd.min.js"></script>
+  {% include "_trix_toolbar_init.html" %}
+{% endblock %}
+
 {% block app_content %}
   <main class="flex-shrink-0">
     <div class="container ps-0">
@@ -20,14 +30,14 @@
 
       <div class="row">
         <div class="col-md-4">
-          <form method="post" novalidate>
+          <form method="post" novalidate x-data @trix-file-accept.window.prevent>
             {% set popover_location_1 = "<p>The first part of the distillery's location.</p><p>If the distillery is in Bardstown, KY, the value for &quot;Location 1&quot; would be <b>Bardstown</b>.</p><p>If the distillery is in Islay, Scotland, the value for &quot;Location 1&quot; would be <b>Islay</b>.</p>" %}
             {% set popover_location_2 = "<p>The second part of the distillery's location.</p><p>If the distillery is in Bardstown, KY, the value for &quot;Location 1&quot; would be <b>KY</b>.</p><p>If the distillery is in Islay, Scotland, the value for &quot;Location 1&quot; would be <b>Scotland</b>.</p>" %}
 
             {{ form.csrf_token }}
 
             {{ form_utils.render_field(form.name) }}
-            {{ form_utils.render_field(form.description) }}
+            {{ form_utils.render_trix_field(form.description) }}
             {{ form_utils.render_field(form.region_1, popover_text=popover_location_1) }}
             {{ form_utils.render_field(form.region_2, popover_text=popover_location_2) }}
             {{ form_utils.render_field(form.url) }}

--- a/mywhiskies/common/filters.py
+++ b/mywhiskies/common/filters.py
@@ -1,7 +1,26 @@
+import re
 from datetime import date, datetime
 from typing import Any
 
+import nh3
 from markupsafe import Markup, escape
+
+_RICH_TEXT_ALLOWED_TAGS = {
+    "a",
+    "b",
+    "blockquote",
+    "br",
+    "del",
+    "div",
+    "em",
+    "h1",
+    "li",
+    "ol",
+    "pre",
+    "strong",
+    "ul",
+}
+_RICH_TEXT_ALLOWED_ATTRS = {"a": {"href", "title"}}
 
 
 def yesno(value: Any, yes: str = "Yes", no: str = "No") -> str:
@@ -53,9 +72,34 @@ def float_or_dash(value: Any, precision: int = 2, fallback: str = "-", dash_clas
     return Markup(escape(formatted))
 
 
+def render_rich_text(value: Any, fallback: str = "-", dash_class: str = "text-muted") -> Markup:
+    """Sanitize stored rich-text HTML and return safe Markup, or a styled dash if empty."""
+    if value is None or (isinstance(value, str) and value.strip() == ""):
+        return Markup(f'<span class="{dash_class}">{escape(fallback)}</span>')
+    sanitized = nh3.clean(
+        str(value),
+        tags=_RICH_TEXT_ALLOWED_TAGS,
+        attributes=_RICH_TEXT_ALLOWED_ATTRS,
+    )
+    return Markup(sanitized)
+
+
+def strip_html(value: Any, max_chars: int = 200) -> str:
+    """Strip HTML tags and return plain text, truncated to max_chars. Safe for use in attributes."""
+    if not value:
+        return ""
+    text = re.sub(r"<[^>]+>", "", str(value))
+    text = text.strip()
+    if len(text) > max_chars:
+        text = text[:max_chars].rstrip() + "…"
+    return text
+
+
 def register_filters(app) -> None:
     app.jinja_env.filters["yesno"] = yesno
     app.jinja_env.filters["multiline_or_dash"] = multiline_or_dash
     app.jinja_env.filters["date_or_dash"] = date_or_dash
     app.jinja_env.filters["value_or_dash"] = value_or_dash
     app.jinja_env.filters["float_or_dash"] = float_or_dash
+    app.jinja_env.filters["render_rich_text"] = render_rich_text
+    app.jinja_env.filters["strip_html"] = strip_html

--- a/mywhiskies/static/css/main.css
+++ b/mywhiskies/static/css/main.css
@@ -537,3 +537,154 @@ ul.terms li {
   outline: 2px solid rgba(255, 255, 255, 0.75);
   outline-offset: 1px;
 }
+
+
+/* ===================================================================
+   Trix rich-text editor — Bootstrap-compatible styling
+   =================================================================== */
+
+/* Toolbar container */
+trix-toolbar {
+  display: block;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-bottom: none;
+  border-radius: 0.375rem 0.375rem 0 0;
+  padding: 4px 6px;
+}
+
+trix-toolbar .trix-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  align-items: center;
+  margin: 0;
+}
+
+trix-toolbar .trix-button-group {
+  display: flex;
+  gap: 1px;
+  border: none;
+  background: none;
+  margin: 0;
+}
+
+trix-toolbar .trix-button-group-spacer {
+  flex: 1;
+}
+
+/* Toolbar buttons — Bootstrap Icons as content, no Trix SVG backgrounds */
+trix-toolbar .trix-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  color: #495057;
+  padding: 3px 7px;
+  font-size: 0.875rem;
+  line-height: 1;
+  cursor: pointer;
+  /* Override Trix's icon-hiding defaults */
+  text-indent: 0;
+  width: auto;
+  height: auto;
+  max-width: none;
+  overflow: visible;
+  float: none;
+}
+
+trix-toolbar .trix-button::before {
+  display: none;
+}
+
+trix-toolbar .trix-button:hover:not(:disabled) {
+  background: #e9ecef;
+  border-color: #dee2e6;
+  color: #212529;
+}
+
+trix-toolbar .trix-button.trix-active {
+  background: #dee2e6;
+  border-color: #adb5bd;
+  color: #212529;
+}
+
+trix-toolbar .trix-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Link dialog */
+trix-toolbar .trix-dialog {
+  padding: 6px 8px;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-top: none;
+  border-radius: 0 0 0.375rem 0.375rem;
+}
+
+trix-toolbar .trix-dialog__link-fields {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+trix-toolbar .trix-input--dialog {
+  flex: 1;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+}
+
+trix-toolbar .trix-button--dialog {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  text-indent: 0;
+  float: none;
+  width: auto;
+  height: auto;
+}
+
+trix-toolbar .trix-button--dialog:hover {
+  background: #e9ecef;
+}
+
+/* Editor content area */
+trix-editor {
+  display: block;
+  border: 1px solid #dee2e6;
+  border-radius: 0 0 0.375rem 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: #212529;
+  background: #fff;
+  min-height: 120px;
+  overflow-y: auto;
+}
+
+/* Focus ring on the whole unit */
+.trix-wrapper:focus-within trix-toolbar {
+  border-color: #86b7fe;
+}
+
+.trix-wrapper:focus-within trix-editor {
+  border-color: #86b7fe;
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.trix-wrapper.is-invalid trix-editor {
+  border-color: #dc3545;
+}
+
+.trix-wrapper.is-invalid ~ .invalid-feedback {
+  display: block;
+}

--- a/mywhiskies/templates/_trix_toolbar_init.html
+++ b/mywhiskies/templates/_trix_toolbar_init.html
@@ -1,0 +1,40 @@
+<script>
+(function () {
+  var toolbarHTML = [
+    '<div class="trix-button-row">',
+    '  <span class="trix-button-group" data-trix-button-group="text-tools">',
+    '    <button type="button" class="trix-button" data-trix-attribute="bold" title="Bold"><i class="bi bi-type-bold"></i></button>',
+    '    <button type="button" class="trix-button" data-trix-attribute="italic" title="Italic"><i class="bi bi-type-italic"></i></button>',
+    '    <button type="button" class="trix-button" data-trix-attribute="strike" title="Strikethrough"><i class="bi bi-type-strikethrough"></i></button>',
+    '  </span>',
+    '  <span class="trix-button-group" data-trix-button-group="link-tools">',
+    '    <button type="button" class="trix-button" data-trix-attribute="href" title="Link"><i class="bi bi-link-45deg"></i></button>',
+    '  </span>',
+    '  <span class="trix-button-group" data-trix-button-group="block-tools">',
+    '    <button type="button" class="trix-button" data-trix-attribute="bullet" title="Bullet list"><i class="bi bi-list-ul"></i></button>',
+    '    <button type="button" class="trix-button" data-trix-attribute="number" title="Numbered list"><i class="bi bi-list-ol"></i></button>',
+    '  </span>',
+    '  <span class="trix-button-group-spacer"></span>',
+    '  <span class="trix-button-group" data-trix-button-group="history-tools">',
+    '    <button type="button" class="trix-button" data-trix-action="undo" title="Undo" disabled><i class="bi bi-arrow-counterclockwise"></i></button>',
+    '    <button type="button" class="trix-button" data-trix-action="redo" title="Redo" disabled><i class="bi bi-arrow-clockwise"></i></button>',
+    '  </span>',
+    '</div>',
+    '<div class="trix-dialogs" data-trix-dialogs>',
+    '  <div class="trix-dialog trix-dialog--link" data-trix-dialog="href" data-trix-dialog-attribute="href">',
+    '    <div class="trix-dialog__link-fields">',
+    '      <input type="url" name="href" class="trix-input trix-input--dialog" placeholder="Enter a URL\u2026" aria-label="URL" required data-trix-input>',
+    '      <div class="trix-button-group">',
+    '        <input type="button" class="trix-button trix-button--dialog" value="Link" data-trix-method="setAttribute">',
+    '        <input type="button" class="trix-button trix-button--dialog" value="Unlink" data-trix-method="removeAttribute">',
+    '      </div>',
+    '    </div>',
+    '  </div>',
+    '</div>'
+  ].join('');
+
+  document.addEventListener('trix-initialize', function (event) {
+    event.target.toolbarElement.innerHTML = toolbarHTML;
+  });
+}());
+</script>

--- a/mywhiskies/templates/macros/forms.html
+++ b/mywhiskies/templates/macros/forms.html
@@ -1,3 +1,20 @@
+{% macro render_trix_field(field, popover_text) %}
+  <div class="mb-3">
+    {{ field.label(class="form-label") }}
+    {{ render_popover(field, popover_text) }}
+    {% if field.flags.required %}<span class="text-danger">*</span>{% endif %}
+    <div class="trix-wrapper{{ ' is-invalid' if field.errors else '' }}">
+      <input type="hidden"
+             id="{{ field.id }}"
+             name="{{ field.name }}"
+             value="{{ field.data or '' }}">
+      <trix-editor input="{{ field.id }}"></trix-editor>
+    </div>
+    {{ render_errors(field) }}
+    {{ render_description(field) }}
+  </div>
+{% endmacro %}
+
 {% macro render_field(field, popover_text) %}
   <div class="mb-3">
     {{ field.label(class="form-label") }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ jmespath==1.0.1
 Mako>=1.3.11
 MarkupSafe==2.1.2
 mysqlclient==2.1.1
+nh3==0.3.5
 numpy==2.1.2
 packaging==24.1
 pandas==2.2.3

--- a/tests/unit/common/test_filters.py
+++ b/tests/unit/common/test_filters.py
@@ -6,6 +6,8 @@ from mywhiskies.common.filters import (
     date_or_dash,
     float_or_dash,
     multiline_or_dash,
+    render_rich_text,
+    strip_html,
     value_or_dash,
     yesno,
 )
@@ -148,3 +150,57 @@ def test_float_or_dash_custom_precision():
 def test_float_or_dash_with_invalid_value():
     result = float_or_dash("not-a-number")
     assert "text-muted" in result
+
+
+# --- render_rich_text ---
+
+
+def test_render_rich_text_with_none():
+    result = render_rich_text(None)
+    assert "text-muted" in result
+    assert "-" in result
+
+
+def test_render_rich_text_with_empty_string():
+    result = render_rich_text("   ")
+    assert "text-muted" in result
+
+
+def test_render_rich_text_passthrough_allowed_tags():
+    result = render_rich_text("<strong>bold</strong>")
+    assert isinstance(result, Markup)
+    assert "<strong>bold</strong>" in result
+
+
+def test_render_rich_text_strips_disallowed_tags():
+    result = render_rich_text("<script>alert('xss')</script>hello")
+    assert "<script>" not in result
+    assert "hello" in result
+
+
+def test_render_rich_text_allows_links():
+    result = render_rich_text('<a href="https://example.com">link</a>')
+    assert 'href="https://example.com"' in result
+    assert ">link</a>" in result
+
+
+# --- strip_html ---
+
+
+def test_strip_html_removes_tags():
+    assert strip_html("<strong>hello</strong>") == "hello"
+
+
+def test_strip_html_with_none():
+    assert strip_html(None) == ""
+
+
+def test_strip_html_truncates():
+    long_text = "a" * 300
+    result = strip_html(long_text)
+    assert len(result) <= 201  # 200 chars + ellipsis
+
+
+def test_strip_html_no_truncation_when_short():
+    result = strip_html("<em>short</em>")
+    assert result == "short"


### PR DESCRIPTION
## Summary

- Replaces plain textareas on all description, personal note, and review fields with the Trix rich-text editor
- Stores content as sanitized HTML via `nh3`; rendered safely through a new `render_rich_text` Jinja2 filter
- Custom slim toolbar (Bold, Italic, Strike, Link, Bullets, Numbers, Undo/Redo) injected via `trix-initialize` using Bootstrap Icons — no dependency on Trix's SVG icon system
- Tooltips on the bottle list use a new `strip_html` filter for plain-text summaries
- File attachment disabled via Alpine (`@trix-file-accept.window.prevent`)

## Test plan

- [ ] Add a bottle — verify all three editors (Description, Personal Note, Review) render with the slim icon toolbar
- [ ] Type and apply bold, italic, strikethrough, link, bullet list, numbered list formatting
- [ ] Save the bottle and verify formatted content renders correctly on the bottle detail page
- [ ] Verify the bottle list tooltip shows plain text (no HTML tags)
- [ ] Repeat for Add/Edit Distillery and Add/Edit Bottler (Description field)
- [ ] Verify file drag-and-drop into the editor is blocked
- [ ] `pytest` passes cleanly