### PR TITLE
fix: replace garish flash and modal colors (#130)

### DIFF
--- a/mywhiskies/blueprints/bottler/templates/bottler/list.html
+++ b/mywhiskies/blueprints/bottler/templates/bottler/list.html
@@ -82,9 +82,9 @@
   <div class="modal fade" id="cannotDelete" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header bg-warning">
+        <div class="modal-header">
           <h1 class="modal-title fs-5">
-            <i class="bi bi-info-circle"></i> This Bottler Cannot be Deleted
+            <i class="bi bi-info-circle text-warning"></i> This Bottler Cannot be Deleted
           </h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal"
             aria-label="Close"></button>
@@ -104,9 +104,9 @@
   <div class="modal fade" id="confirmDelete" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header bg-danger">
-          <h1 class="modal-title fs-5 text-white">
-            <i class="bi bi-exclamation-circle"></i> Confirm Deletion
+        <div class="modal-header">
+          <h1 class="modal-title fs-5">
+            <i class="bi bi-exclamation-circle text-danger"></i> Confirm Deletion
           </h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal"
             aria-label="Close"></button>

--- a/mywhiskies/blueprints/distillery/templates/distillery/list.html
+++ b/mywhiskies/blueprints/distillery/templates/distillery/list.html
@@ -80,9 +80,9 @@
   <div class="modal fade" id="cannotDelete" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header bg-warning">
+        <div class="modal-header">
           <h1 class="modal-title fs-5">
-            <i class="bi bi-info-circle"></i> This Distillery Cannot be Deleted
+            <i class="bi bi-info-circle text-warning"></i> This Distillery Cannot be Deleted
           </h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal"
             aria-label="Close"></button>
@@ -102,9 +102,9 @@
   <div class="modal fade" id="confirmDelete" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header bg-danger">
-          <h1 class="modal-title fs-5 text-white">
-            <i class="bi bi-exclamation-circle"></i> Confirm Deletion
+        <div class="modal-header">
+          <h1 class="modal-title fs-5">
+            <i class="bi bi-exclamation-circle text-danger"></i> Confirm Deletion
           </h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal"
             aria-label="Close"></button>

--- a/mywhiskies/templates/flash.html
+++ b/mywhiskies/templates/flash.html
@@ -12,8 +12,8 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
     {% for category, message in messages %}
-      {% if category == "message" %}
-        {% set category = "info" %}
+      {% if category == "message" or category == "info" %}
+        {% set category = "secondary" %}
       {% endif %}
       <div class="container mt-4 ps-0">
         <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert" data-auto-dismiss>


### PR DESCRIPTION
## Summary

- Flash `info`/`message` category now renders as `alert-secondary` (neutral grey) instead of `alert-info` (bright cyan/blue)
- Removed `bg-warning` and `bg-danger` colored backgrounds from modal headers in bottler and distillery list pages — the severity icon now carries the color (`text-warning` / `text-danger`) instead of painting the whole header

Closes #130

## Test plan

- [ ] Trigger an info flash (e.g. visit a protected page while logged out) — should appear grey/neutral
- [ ] Trigger a success flash (e.g. edit a bottle) — should still appear green
- [ ] Click trash on a bottler/distillery that has bottles — "Cannot be Deleted" modal should show plain white header with amber info icon
- [ ] Click trash on a bottler/distillery with no bottles — "Confirm Deletion" modal should show plain white header with red exclamation icon