### PR TITLE
fix: initialize carousel on load so touch/swipe works immediately

### DIFF
--- a/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
+++ b/mywhiskies/blueprints/bottle/templates/bottle/bottle.html
@@ -257,6 +257,7 @@
               <script>
                 (function () {
                   const el = document.getElementById('bottleCarousel');
+                  bootstrap.Carousel.getOrCreateInstance(el, { ride: false, interval: false, touch: true });
                   const dots = document.querySelectorAll('.carousel-dot');
                   el.addEventListener('slide.bs.carousel', e => {
                     dots.forEach((d, i) => d.classList.toggle('active', i === e.to));


### PR DESCRIPTION
Bootstrap carousel with `data-bs-ride="false"` initializes lazily — touch handlers aren't attached until the first Prev/Next click. Force-initialize via `getOrCreateInstance` on page load so swiping works immediately.

## Test plan
- [ ] Open a bottle detail page with multiple images on mobile
- [ ] Swipe left/right without tapping Prev or Next first — should work