### PR TITLE
fix: upgrade python-dotenv to 1.2.2 (CVE-2026-28684)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pytest==9.0.3
 pytest-cov==6.0.0
 pytest-flask==1.3.0
 python-dateutil==2.8.2
-python-dotenv==0.21.1
+python-dotenv==1.2.2
 pytz==2024.2
 PyYAML==6.0.2
 requests==2.33.1


### PR DESCRIPTION
## Summary

- Bumps `python-dotenv` from `0.21.1` → `1.2.2`
- Resolves Dependabot alert #42: symlink-following vulnerability ([GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94), CVE-2026-28684, CVSS 6.6 medium)
- The vulnerability allowed a local attacker to overwrite arbitrary files via a crafted symlink when `set_key()`/`unset_key()` triggered a cross-device rename fallback

## Test plan

- [x] `ruff check` and `ruff format` clean
- [x] `pytest --cov=mywhiskies tests/` — 211 passed